### PR TITLE
Update target framework to .NET 10.0 across multiple projects

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '10.x'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/deepsorce.yml
+++ b/.github/workflows/deepsorce.yml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: '8.0.x' # set this to the dotnet version to use
+  DOTNET_VERSION: '10.0.x' # set this to the dotnet version to use
 
 jobs:
   analyze:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
 
       - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
@@ -72,7 +72,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.x
+          dotnet-version: 10.x
 
       - name: Dotnet Build
         run: dotnet build --configuration Release

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: '8.0.x' # set this to the dotnet version to use
+  DOTNET_VERSION: '10.0.x' # set this to the dotnet version to use
 
 jobs:
   sonarqube:

--- a/LostFilmMonitoring.AzureFunction/LostFilmMonitoring.AzureFunction.csproj
+++ b/LostFilmMonitoring.AzureFunction/LostFilmMonitoring.AzureFunction.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
@@ -15,9 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.20.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="10.0.5" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />

--- a/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoring.AzureInfrastructure.csproj
+++ b/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoring.AzureInfrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
+++ b/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
@@ -480,7 +480,7 @@ public class LostFilmMonitoringStack : Pulumi.Stack
             },
             SiteConfig = new Azure.Web.Inputs.SiteConfigArgs
             {
-                LinuxFxVersion = "DOTNET-ISOLATED|8.0",
+                LinuxFxVersion = "DOTNET-ISOLATED|10.0",
                 AppSettings = GetAppSettings(new Dictionary<Pulumi.Input<string>, Pulumi.Input<string>>
                 {
                     { "APPLICATIONINSIGHTS_CONNECTION_STRING", appi.ConnectionString },

--- a/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
+++ b/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using LostFilmMonitoring.Common;
 using Pulumi;
-using Pulumi.AzureNative.Maps;
 using Azure = Pulumi.AzureNative;
 using Cloudflare = Pulumi.Cloudflare;
 
@@ -420,7 +419,7 @@ public class LostFilmMonitoringStack : Pulumi.Stack
                 Runtime = new Azure.Web.Inputs.FunctionsRuntimeArgs
                 {
                     Name = "dotnet-isolated",
-                    Version = "8.0"
+                    Version = "10.0"
                 },
                 ScaleAndConcurrency = new Azure.Web.Inputs.FunctionsScaleAndConcurrencyArgs
                 {

--- a/LostFilmMonitoring.BLL.Tests/LostFilmMonitoring.BLL.Tests.csproj
+++ b/LostFilmMonitoring.BLL.Tests/LostFilmMonitoring.BLL.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/LostFilmMonitoring.BLL/LostFilmMonitoring.BLL.csproj
+++ b/LostFilmMonitoring.BLL/LostFilmMonitoring.BLL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
+      <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/LostFilmMonitoring.Common/LostFilmMonitoring.Common.csproj
+++ b/LostFilmMonitoring.Common/LostFilmMonitoring.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/LostFilmMonitoring.DAO.Azure.Tests/LostFilmMonitoring.DAO.Azure.Tests.csproj
+++ b/LostFilmMonitoring.DAO.Azure.Tests/LostFilmMonitoring.DAO.Azure.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/LostFilmMonitoring.DAO.Azure/LostFilmMonitoring.DAO.Azure.csproj
+++ b/LostFilmMonitoring.DAO.Azure/LostFilmMonitoring.DAO.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/LostFilmMonitoring.DAO.Interfaces/LostFilmMonitoring.DAO.Interfaces.csproj
+++ b/LostFilmMonitoring.DAO.Interfaces/LostFilmMonitoring.DAO.Interfaces.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/LostFilmMonitoring.TorrentFileImpl.Tests/LostFilmMonitoring.TorrentFileImpl.Tests.csproj
+++ b/LostFilmMonitoring.TorrentFileImpl.Tests/LostFilmMonitoring.TorrentFileImpl.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/LostFilmMonitoring.TorrentFileImpl/LostFilmMonitoring.TorrentFileImpl.csproj
+++ b/LostFilmMonitoring.TorrentFileImpl/LostFilmMonitoring.TorrentFileImpl.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/LostFilmTV.Client.Tests/LostFilmTV.Client.Tests.csproj
+++ b/LostFilmTV.Client.Tests/LostFilmTV.Client.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
@@ -39,7 +39,6 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LostFilmTV.Client/LostFilmTV.Client.csproj
+++ b/LostFilmTV.Client/LostFilmTV.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Copyright>MIT</Copyright>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>

--- a/TMDB.Client/TMDB.Client.csproj
+++ b/TMDB.Client/TMDB.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
- Changed target framework from net8.0 to net10.0 in LostFilmMonitoring.AzureFunction, LostFilmMonitoring.AzureInfrastructure, LostFilmMonitoring.BLL, LostFilmMonitoring.Common, LostFilmMonitoring.DAO.Azure, LostFilmMonitoring.DAO.Interfaces, LostFilmMonitoring.TorrentFileImpl, LostFilmTV.Client, and their respective test projects.
- Removed outdated package references in LostFilmMonitoring.AzureFunction.