### PR TITLE
[codex] Remove FluentAssertions from tests

### DIFF
--- a/LostFilmMonitoring.BLL.Tests/AGENTS.md
+++ b/LostFilmMonitoring.BLL.Tests/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Testing Framework
 
-- NUnit + Moq + FluentAssertions
+- NUnit + Moq
 - All test classes marked `[ExcludeFromCodeCoverage]`
 
 ## Test Structure
@@ -32,7 +32,7 @@ internal class MyCommandTests
         var result = await command.ExecuteAsync(request);
         
         // Assert
-        result.Should().NotBeNull();
+        Assert.That(result, Is.Not.Null);
         dal.Verify(x => x.Method(...), Times.Once);
     }
 }
@@ -50,8 +50,8 @@ internal class MyCommandTests
 // Verify DAO calls
 dal.Verify(x => x.SaveAsync(It.IsAny<User>()), Times.Once);
 
-// FluentAssertions
-result.Should().NotBeNull();
-result.UserId.Should().NotBeNullOrEmpty();
-result.IsSuccess.Should().BeTrue();
+// NUnit assertions
+Assert.That(result, Is.Not.Null);
+Assert.That(result.UserId, Is.Not.Null.And.Not.Empty);
+Assert.That(result.IsSuccess, Is.True);
 ```

--- a/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImageCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImageCommandTests.cs
@@ -28,7 +28,7 @@ public class DownloadCoverImageCommandTests
             null!,
             this.fileSystem!.Object,
             this.tmdbClient!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -38,7 +38,7 @@ public class DownloadCoverImageCommandTests
             this.logger!.Object,
             null!,
             this.tmdbClient!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("fileSystem");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("fileSystem"));
     }
 
     [Test]
@@ -48,7 +48,7 @@ public class DownloadCoverImageCommandTests
             this.logger!.Object,
             this.fileSystem!.Object,
             null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("tmdbClient");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("tmdbClient"));
     }
 
     [Test]
@@ -67,7 +67,7 @@ public class DownloadCoverImageCommandTests
     {
         var command = GetService();
         var action = async () => await command.ExecuteAsync(null!);
-        await action.Should().ThrowAsync<ArgumentNullException>();
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await action());
     }
 
     #endregion

--- a/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.BLL.Tests.Commands;
+namespace LostFilmMonitoring.BLL.Tests.Commands;
 
 [ExcludeFromCodeCoverage]
 public class DownloadCoverImagesCommandTests
@@ -28,7 +28,7 @@ public class DownloadCoverImagesCommandTests
             null!,
             this.seriesDao!.Object,
             this.downloadCoverImageCommand!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -38,7 +38,7 @@ public class DownloadCoverImagesCommandTests
             this.logger!.Object,
             null!,
             this.downloadCoverImageCommand!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("seriesDao");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("seriesDao"));
     }
 
     [Test]
@@ -48,7 +48,7 @@ public class DownloadCoverImagesCommandTests
             this.logger!.Object,
             this.seriesDao!.Object,
             null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("downloadCoverImageCommand");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("downloadCoverImageCommand"));
     }
 
     [Test]
@@ -122,9 +122,9 @@ public class DownloadCoverImagesCommandTests
 
         await command.ExecuteAsync();
 
-        callOrder.Should().HaveCount(2);
-        callOrder[0].Should().Be(series1);
-        callOrder[1].Should().Be(series2);
+        Assert.That(callOrder, Has.Count.EqualTo(2));
+        Assert.That(callOrder[0], Is.EqualTo(series1));
+        Assert.That(callOrder[1], Is.EqualTo(series2));
     }
 
     [Test]
@@ -168,7 +168,7 @@ public class DownloadCoverImagesCommandTests
             .ThrowsAsync(new InvalidOperationException("Download failed"));
 
         var action = async () => await command.ExecuteAsync();
-        await action.Should().ThrowAsync<InvalidOperationException>();
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await action());
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs
@@ -18,14 +18,14 @@ internal class GetUserCommandTests
     public void Constructor_should_throw_exception_when_userDao_null()
     {
         var action = () => new GetUserCommand(null!, this.logger!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("userDao");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("userDao"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new GetUserCommand(this.userDao!.Object, null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -33,7 +33,7 @@ internal class GetUserCommandTests
     {
         this.logger!.Setup(x => x.CreateScope(It.IsAny<string>())).Returns((null as Common.ILogger)!);
         var action = () => new GetUserCommand(this.userDao!.Object, this.logger.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -41,10 +41,10 @@ internal class GetUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(null);
-        response.TrackerId.Should().BeNull();
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "model", Value = ErrorMessages.RequestNull });
+        Assert.That(response.TrackerId, Is.Null);
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, "model", ErrorMessages.RequestNull);
     }
 
     [Test]
@@ -52,10 +52,10 @@ internal class GetUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new GetUserRequestModel());
-        response.TrackerId.Should().BeNull();
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = nameof(GetUserRequestModel.UserId), Value = string.Format(ErrorMessages.FieldEmpty, nameof(GetUserRequestModel.UserId)) });
+        Assert.That(response.TrackerId, Is.Null);
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.FieldEmpty, nameof(GetUserRequestModel.UserId)));
     }
 
     [Test]
@@ -65,10 +65,10 @@ internal class GetUserCommandTests
         this.userDao!.Setup(x => x.LoadAsync(It.IsAny<string>())).ReturnsAsync(null as User);
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new GetUserRequestModel { UserId = testUserIdValue });
-        response.TrackerId.Should().BeNull();
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = nameof(GetUserRequestModel.UserId), Value = string.Format(ErrorMessages.UserDoesNotExist, nameof(GetUserRequestModel.UserId), testUserIdValue) });
+        Assert.That(response.TrackerId, Is.Null);
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.UserDoesNotExist, nameof(GetUserRequestModel.UserId), testUserIdValue));
     }
 
     [Test]
@@ -78,10 +78,10 @@ internal class GetUserCommandTests
         this.userDao!.Setup(x => x.LoadAsync(It.IsAny<string>())).ReturnsAsync(new User(string.Empty, testTrackerIdValue));
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new GetUserRequestModel { UserId = "123" });
-        response.TrackerId.Should().Be(testTrackerIdValue);
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeTrue();
-        response.ValidationResult.Errors.Count.Should().Be(0);
+        Assert.That(response.TrackerId, Is.EqualTo(testTrackerIdValue));
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.True);
+        Assert.That(response.ValidationResult.Errors.Count, Is.EqualTo(0));
     }
 
     private GetUserCommand CreateCommand() => new(this.userDao!.Object, this.logger!.Object);

--- a/LostFilmMonitoring.BLL.Tests/Commands/SaveSubscriptionCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/SaveSubscriptionCommandTests.cs
@@ -59,7 +59,7 @@ internal class SaveSubscriptionCommandTests
             this.persister!.Object,
             this.torrentFileHelper!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -73,7 +73,7 @@ internal class SaveSubscriptionCommandTests
             this.persister!.Object,
             this.torrentFileHelper!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("validator");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("validator"));
     }
 
     [Test]
@@ -87,7 +87,7 @@ internal class SaveSubscriptionCommandTests
             this.persister!.Object,
             this.torrentFileHelper!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("dal");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("dal"));
     }
 
     [Test]
@@ -101,7 +101,7 @@ internal class SaveSubscriptionCommandTests
             this.persister!.Object,
             this.torrentFileHelper!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("configuration");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("configuration"));
     }
 
     [Test]
@@ -115,7 +115,7 @@ internal class SaveSubscriptionCommandTests
             null!,
             this.torrentFileHelper!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("persister");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("persister"));
     }
 
     [Test]
@@ -129,7 +129,7 @@ internal class SaveSubscriptionCommandTests
             this.persister!.Object,
             null!
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("torrentFileHelper");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("torrentFileHelper"));
     }
 
     [Test]
@@ -164,7 +164,7 @@ internal class SaveSubscriptionCommandTests
 
         var command = GetCommand();
         var response = await command.ExecuteAsync(new EditSubscriptionRequestModel() { UserId = "123", Items = [ new SubscriptionItem() ] });
-        response.ValidationResult.Should().Be(validationError);
+        Assert.That(response.ValidationResult, Is.EqualTo(validationError));
     }
 
     [Test]
@@ -332,9 +332,9 @@ internal class SaveSubscriptionCommandTests
 
     private static void Verify(EditSubscriptionResponseModel response, string errorKey, string errorValue)
     {
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = errorKey, Value = errorValue });
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, errorKey, errorValue);
     }
 
     private SaveSubscriptionCommand GetCommand()

--- a/LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs
@@ -22,28 +22,28 @@ internal class SaveUserCommandTests
     public void Constructor_should_throw_exception_when_userDao_null()
     {
         var action = () => new SaveUserCommand(null!, this.logger!.Object, this.persister!.Object, this.feedDao!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("userDao");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("userDao"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new SaveUserCommand(this.userDao!.Object, null!, this.persister!.Object, this.feedDao!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_persister_null()
     {
         var action = () => new SaveUserCommand(this.userDao!.Object, this.logger!.Object, null!, this.feedDao!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("persister");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("persister"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_feedDao_null()
     {
         var action = () => new SaveUserCommand(this.userDao!.Object, this.logger!.Object, this.persister!.Object, null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("feedDao");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("feedDao"));
     }
 
     [Test]
@@ -51,7 +51,7 @@ internal class SaveUserCommandTests
     {
         this.logger!.Setup(x => x.CreateScope(It.IsAny<string>())).Returns((null as Common.ILogger)!);
         var action = () => new SaveUserCommand(this.userDao!.Object, this.logger.Object, this.persister!.Object, this.feedDao!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -59,10 +59,10 @@ internal class SaveUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(null);
-        response.UserId.Should().BeNull();
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "model", Value = ErrorMessages.RequestNull });
+        Assert.That(response.UserId, Is.Null);
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, "model", ErrorMessages.RequestNull);
     }
 
     [Test]
@@ -70,10 +70,10 @@ internal class SaveUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new EditUserRequestModel());
-        response.UserId.Should().BeNull();
-        response.ValidationResult.Should().NotBeNull();
-        response.ValidationResult.IsValid.Should().BeFalse();
-        response.ValidationResult.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = nameof(EditUserRequestModel.TrackerId), Value = string.Format(ErrorMessages.FieldEmpty, nameof(EditUserRequestModel.TrackerId)) });
+        Assert.That(response.UserId, Is.Null);
+        Assert.That(response.ValidationResult, Is.Not.Null);
+        Assert.That(response.ValidationResult.IsValid, Is.False);
+        TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(EditUserRequestModel.TrackerId), string.Format(ErrorMessages.FieldEmpty, nameof(EditUserRequestModel.TrackerId)));
     }
 
     [Test]
@@ -82,7 +82,7 @@ internal class SaveUserCommandTests
         var trackerIdValue = "TrackerId";
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new EditUserRequestModel() { UserId = null, TrackerId = trackerIdValue });
-        response.UserId.Should().NotBeNull();
+        Assert.That(response.UserId, Is.Not.Null);
     }
 
     [Test]
@@ -92,7 +92,7 @@ internal class SaveUserCommandTests
         var userIdValue = "UserId";
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new EditUserRequestModel() { UserId = userIdValue, TrackerId = trackerIdValue });
-        response.UserId.Should().Be(userIdValue);
+        Assert.That(response.UserId, Is.EqualTo(userIdValue));
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/Commands/SignInCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/SignInCommandTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.BLL.Tests.Commands;
+namespace LostFilmMonitoring.BLL.Tests.Commands;
 
 [ExcludeFromCodeCoverage]
 internal class SignInCommandTests
@@ -19,7 +19,7 @@ internal class SignInCommandTests
     {
         var command = CreateSignInCommand();
         var response = await command.ExecuteAsync(null);
-        response.Success.Should().BeFalse();
+        Assert.That(response.Success, Is.False);
     }
 
     [Test]
@@ -27,7 +27,7 @@ internal class SignInCommandTests
     {
         var command = CreateSignInCommand();
         var response = await command.ExecuteAsync(new Models.Request.SignInRequestModel());
-        response.Success.Should().BeFalse();
+        Assert.That(response.Success, Is.False);
     }
 
     [Test]
@@ -36,7 +36,7 @@ internal class SignInCommandTests
         this.userDao!.Setup(x => x.LoadAsync(It.IsAny<string>())).ReturnsAsync(null as User);
         var command = CreateSignInCommand();
         var response = await command.ExecuteAsync(new Models.Request.SignInRequestModel { UserId = "123" });
-        response.Success.Should().BeFalse();
+        Assert.That(response.Success, Is.False);
     }
 
     [Test]
@@ -45,21 +45,21 @@ internal class SignInCommandTests
         this.userDao!.Setup(x => x.LoadAsync(It.IsAny<string>())).ReturnsAsync(new User(string.Empty, string.Empty));
         var command = CreateSignInCommand();
         var response = await command.ExecuteAsync(new Models.Request.SignInRequestModel { UserId = "123" });
-        response.Success.Should().BeTrue();
+        Assert.That(response.Success, Is.True);
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_userDao_null()
     {
         var action = () => new SignInCommand(null!, this.logger!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("userDao");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("userDao"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new SignInCommand(this.userDao!.Object, null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -67,7 +67,7 @@ internal class SignInCommandTests
     {
         this.logger!.Setup(x => x.CreateScope(It.IsAny<string>())).Returns((null as Common.ILogger)!);
         var action = () => CreateSignInCommand();
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     private SignInCommand CreateSignInCommand() => new(this.userDao!.Object, this.logger!.Object);

--- a/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
@@ -78,7 +78,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("rssFeed");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("rssFeed"));
     }
 
     [Test]
@@ -108,7 +108,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("dal");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("dal"));
     }
 
     [Test]
@@ -123,7 +123,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("configuration");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("configuration"));
     }
 
     [Test]
@@ -138,7 +138,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("modelPersister");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("modelPersister"));
     }
 
     [Test]
@@ -153,7 +153,7 @@ public class UpdateFeedsCommandTests
             null!,
             this.downloadCoverImagesCommand!.Object,
             this.torrentFileHelper!.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("client");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("client"));
     }
 
     [Test]
@@ -168,7 +168,7 @@ public class UpdateFeedsCommandTests
             this.lostFilmClient!.Object,
             this.downloadCoverImagesCommand!.Object,
             null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("torrentFileHelper");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("torrentFileHelper"));
     }
 
     [Test]
@@ -295,16 +295,16 @@ public class UpdateFeedsCommandTests
         await command.ExecuteAsync();
 
         // Verify series is saved with initial empty ID
-        savedSeries.Should().Contain(x => x.Id == Guid.Empty);
+        Assert.That(savedSeries.Any(x => x.Id == Guid.Empty), Is.True);
         // Verify series is saved with final properties
-        savedSeries.Should().Contain(x => 
+        Assert.That(savedSeries.Any(x => 
             x.Id == newSeriesId
          && x.Name == "Флэш (The Flash)"
          && x.LastEpisodeName == "Флэш (The Flash). Падение смерти (S08E13) "
          && x.LastEpisode == new DateTime(2022, 5, 21, 20, 58, 00, DateTimeKind.Utc)
          && x.LastEpisodeTorrentLink1080 == "http://n.tracktor.site/rssdownloader.php?id=51438"
          && x.LastEpisodeTorrentLinkMP4 == "http://n.tracktor.site/rssdownloader.php?id=51439"
-         && x.LastEpisodeTorrentLinkSD == "http://n.tracktor.site/rssdownloader.php?id=51437");
+         && x.LastEpisodeTorrentLinkSD == "http://n.tracktor.site/rssdownloader.php?id=51437"), Is.True);
     }
 
     [Test]
@@ -810,7 +810,7 @@ public class UpdateFeedsCommandTests
     private void SetupTorrentFile(string torrentId)
     {
         var torrentFileStream = typeof(UpdateFeedsCommandTests).Assembly.GetManifestResourceStream("LostFilmMonitoring.BLL.Tests.51439.torrent");
-        torrentFileStream.Should().NotBeNull();
+        Assert.That(torrentFileStream, Is.Not.Null);
         var torrentFileResponse = new Mock<ITorrentFileResponse>(); 
         torrentFileResponse.Setup(x => x.FileName).Returns("Флэш (The Flash). Падение смерти (S08E13) [MP4].torrent");
         torrentFileResponse.Setup(x => x.Content).Returns(torrentFileStream);

--- a/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.BLL.Tests;
+namespace LostFilmMonitoring.BLL.Tests;
 
 [ExcludeFromCodeCoverage]
 public class ConfigurationTests
@@ -21,10 +21,10 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
         var service = GetService();
-        service.BaseUID.Should().BeEquivalentTo("BASELINKUID");
-        service.BaseUSESS.Should().BeEquivalentTo("BASEFEEDCOOKIE");
-        service.BaseUrl.Should().BeEquivalentTo("BASEURL");
-        service.GetTorrentAnnounceList("USERID").Should().BeEquivalentTo(["#1USERID", "#2USERID", "#3USERID"]);
+        Assert.That(service.BaseUID, Is.EqualTo("BASELINKUID"));
+        Assert.That(service.BaseUSESS, Is.EqualTo("BASEFEEDCOOKIE"));
+        Assert.That(service.BaseUrl, Is.EqualTo("BASEURL"));
+        Assert.That(service.GetTorrentAnnounceList("USERID"), Is.EqualTo(["#1USERID", "#2USERID", "#3USERID"]));
     }
 
     [Test]
@@ -37,7 +37,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
         var service = GetService();
-        service.GetTorrentAnnounceList(null!).Should().BeEquivalentTo(["#1BASELINKUID", "#2BASELINKUID", "#3BASELINKUID"]);
+        Assert.That(service.GetTorrentAnnounceList(null!), Is.EqualTo(["#1BASELINKUID", "#2BASELINKUID", "#3BASELINKUID"]));
     }
 
     [Test]
@@ -51,7 +51,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
         
         var action = () => GetService();
-        action.Should().Throw<Exception>().WithMessage("Environment variable 'BASEURL' is not defined.");
+        Assert.That(Assert.Catch<Exception>(() => action())!.Message, Is.EqualTo("Environment variable 'BASEURL' is not defined."));
     }
 
     [Test]
@@ -65,7 +65,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
 
         var action = () => GetService();
-        action.Should().Throw<Exception>().WithMessage("Environment variable 'BASEFEEDCOOKIE' is not defined.");
+        Assert.That(Assert.Catch<Exception>(() => action())!.Message, Is.EqualTo("Environment variable 'BASEFEEDCOOKIE' is not defined."));
     }
 
     [Test]
@@ -79,7 +79,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
 
         var action = () => GetService();
-        action.Should().Throw<Exception>().WithMessage("Environment variable 'BASELINKUID' is not defined.");
+        Assert.That(Assert.Catch<Exception>(() => action())!.Message, Is.EqualTo("Environment variable 'BASELINKUID' is not defined."));
     }
 
     [Test]
@@ -93,7 +93,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
 
         var action = () => GetService();
-        action.Should().Throw<Exception>().WithMessage("Environment variable 'TORRENTTRACKERS' is not defined.");
+        Assert.That(Assert.Catch<Exception>(() => action())!.Message, Is.EqualTo("Environment variable 'TORRENTTRACKERS' is not defined."));
     }
 
     private Configuration GetService() => new (providerMock!.Object);

--- a/LostFilmMonitoring.BLL.Tests/ExtensionsTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/ExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.BLL.Tests;
+namespace LostFilmMonitoring.BLL.Tests;
 
 [ExcludeFromCodeCoverage]
 public class ExtensionsTests
@@ -55,7 +55,7 @@ public class ExtensionsTests
                 },
             ]);
 
-        Extensions.HasUpdates(newItems, existingItems).Should().BeFalse();
+        Assert.That(Extensions.HasUpdates(newItems, existingItems), Is.False);
     }
 
     [Test]
@@ -103,7 +103,7 @@ public class ExtensionsTests
                 },
             ]);
 
-        Extensions.HasUpdates(newItems, existingItems).Should().BeTrue();
+        Assert.That(Extensions.HasUpdates(newItems, existingItems), Is.True);
     }
 
     [Test]
@@ -158,7 +158,7 @@ public class ExtensionsTests
                 },
             ]);
 
-        Extensions.HasUpdates(newItems, existingItems).Should().BeTrue();
+        Assert.That(Extensions.HasUpdates(newItems, existingItems), Is.True);
     }
 
     [Test]
@@ -167,7 +167,7 @@ public class ExtensionsTests
         SortedSet<FeedItemResponse> oldItems = [];
         SortedSet<FeedItemResponse> newItems = null!;
         Action act = () => Extensions.HasUpdates(oldItems, newItems);
-        act.Should().Throw<ArgumentNullException>();
+        Assert.Throws<ArgumentNullException>(() => act());
     }
 
     [Test]
@@ -176,6 +176,6 @@ public class ExtensionsTests
         SortedSet<FeedItemResponse> oldItems = null!;
         SortedSet<FeedItemResponse> newItems = [];
         Action act = () => Extensions.HasUpdates(oldItems, newItems);
-        act.Should().Throw<ArgumentNullException>();
+        Assert.Throws<ArgumentNullException>(() => act());
     }
 }   

--- a/LostFilmMonitoring.BLL.Tests/LoggerTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/LoggerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.BLL.Tests;
+namespace LostFilmMonitoring.BLL.Tests;
 
 [ExcludeFromCodeCoverage]
 public class LoggerTests
@@ -18,7 +18,7 @@ public class LoggerTests
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new Logger(null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("loggerFactory");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("loggerFactory"));
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/LostFilmMonitoring.BLL.Tests.csproj
+++ b/LostFilmMonitoring.BLL.Tests/LostFilmMonitoring.BLL.Tests.csproj
@@ -17,11 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/LostFilmMonitoring.BLL.Tests/TestAssert.cs
+++ b/LostFilmMonitoring.BLL.Tests/TestAssert.cs
@@ -1,0 +1,12 @@
+namespace LostFilmMonitoring.BLL.Tests;
+
+[ExcludeFromCodeCoverage]
+internal static class TestAssert
+{
+    public static void HasSingleError(Dictionary<string, string> errors, string key, string value)
+    {
+        Assert.That(errors, Has.Count.EqualTo(1));
+        Assert.That(errors.Single().Key, Is.EqualTo(key));
+        Assert.That(errors.Single().Value, Is.EqualTo(value));
+    }
+}

--- a/LostFilmMonitoring.BLL.Tests/Usings.cs
+++ b/LostFilmMonitoring.BLL.Tests/Usings.cs
@@ -1,9 +1,8 @@
-﻿global using NUnit.Framework;
+global using NUnit.Framework;
 global using LostFilmMonitoring.BLL.Commands;
 global using LostFilmMonitoring.Common;
 global using LostFilmMonitoring.DAO.Interfaces;
 global using Moq;
-global using FluentAssertions;
 global using LostFilmMonitoring.DAO.Interfaces.DomainModels;
 global using LostFilmMonitoring.BLL.Localization;
 global using LostFilmMonitoring.BLL.Models.Request;

--- a/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
@@ -20,7 +20,7 @@ public class EditSubscriptionRequestModelValidatorTests
             null!,
             this.seriesDao!.Object
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("userDAO");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("userDAO"));
     }
 
     [Test]
@@ -30,47 +30,47 @@ public class EditSubscriptionRequestModelValidatorTests
             this.userDao!.Object,
             null!
         );
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("seriesDAO");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("seriesDAO"));
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_model_is_null()
     {
         var result = await GetService().ValidateAsync(null!);
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "UserId", Value = "Field 'UserId' is empty." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "UserId", "Field 'UserId' is empty.");
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_userId_is_null()
     {
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel());
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "UserId", Value = "Field 'UserId' is empty." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "UserId", "Field 'UserId' is empty.");
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_items_is_null()
     {
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId"});
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "Items", Value = "Field 'Items' is empty." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "Items", "Field 'Items' is empty.");
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_item_seriesName_is_null()
     {
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem()] });
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "SeriesId", Value = "Field 'SeriesId' is empty." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "SeriesId", "Field 'SeriesId' is empty.");
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_item_quality_is_null()
     {
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem() { SeriesId = "Series1" }] });
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "Quality", Value = "Field 'Quality' should be in [SD, 1080, MP4]." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "Quality", "Field 'Quality' should be in [SD, 1080, MP4].");
     }
 
     [Test]
@@ -78,16 +78,16 @@ public class EditSubscriptionRequestModelValidatorTests
     {
         this.seriesDao!.Setup(x => x.LoadAsync("Series1")).ReturnsAsync(null as Series);
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem() { SeriesId = "Series1", Quality = "SD" }] });
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "SeriesId", Value = "Series 'Series1' does not exist." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "SeriesId", "Series 'Series1' does not exist.");
     }
 
     [Test]
     public async Task ValidateAsync_should_return_fail_when_item_userId_is_invalid()
     {
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = []});
-        result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Key = "UserId", Value = "User with Id 'userId' does not exist." });
+        Assert.That(result.IsValid, Is.False);
+        TestAssert.HasSingleError(result.Errors, "UserId", "User with Id 'userId' does not exist.");
     }
 
     [Test]
@@ -97,8 +97,8 @@ public class EditSubscriptionRequestModelValidatorTests
         this.seriesDao!.Setup(x => x.LoadAsync()).ReturnsAsync([testSeries]);
         this.userDao!.Setup(x => x.LoadAsync("userId")).ReturnsAsync(new User(string.Empty, string.Empty));
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem() { SeriesId = "11111111-1111-1111-1111-111111111111", Quality = "SD" }] });
-        result.IsValid.Should().BeTrue();
-        result.Errors.Should().BeEmpty();
+        Assert.That(result.IsValid, Is.True);
+        Assert.That(result.Errors, Is.Empty);
     }
 
     private EditSubscriptionRequestModelValidator GetService() => new(

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureBlobStorageClientTests
@@ -70,14 +70,14 @@ public class AzureBlobStorageClientTests
         var content = "<?xml version=\"1.0\" encoding=\"utf-8\"?><rss></rss>";
         await azureBlobStorageClient.UploadAsync(containerName, blobName, content, "contentType");
 
-        captured.Should().NotBeNull();
+        Assert.That(captured, Is.Not.Null);
         var bytes = ReadFully(captured);
         // Ensure there is no UTF-8 BOM at the start
         if (bytes.Length >= 3)
         {
-            bytes[0].Should().NotBe((byte)0xEF);
-            bytes[1].Should().NotBe((byte)0xBB);
-            bytes[2].Should().NotBe((byte)0xBF);
+            Assert.That(bytes[0], Is.Not.EqualTo((byte)0xEF));
+            Assert.That(bytes[1], Is.Not.EqualTo((byte)0xBB));
+            Assert.That(bytes[2], Is.Not.EqualTo((byte)0xBF));
         }
     }
 
@@ -106,7 +106,7 @@ public class AzureBlobStorageClientTests
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadAsync(containerName, blobName);
         var resultData = Encoding.UTF8.GetString(ReadFully(result));
-        string.Equals(testData, resultData).Should().BeTrue();
+        Assert.That(string.Equals(testData, resultData), Is.True);
     }
 
     [Test]
@@ -125,7 +125,7 @@ public class AzureBlobStorageClientTests
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadAsync(containerName, dirName, blobName);
         var resultData = Encoding.UTF8.GetString(ReadFully(result));
-        string.Equals(testData, resultData).Should().BeTrue();
+        Assert.That(string.Equals(testData, resultData), Is.True);
     }
 
     [Test]
@@ -137,7 +137,7 @@ public class AzureBlobStorageClientTests
 
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadAsync(containerName, dirName, blobName);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -148,7 +148,7 @@ public class AzureBlobStorageClientTests
             .ThrowsAsync(new RequestFailedException(404, "BlobNotFound", "BlobNotFound", null));
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadAsync(containerName, blobName);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -159,7 +159,7 @@ public class AzureBlobStorageClientTests
             .Setup(x => x.DownloadToAsync(It.IsAny<Stream>()))
             .ThrowsAsync(new Exception());
         var func = async () => { await azureBlobStorageClient.DownloadAsync("containerName", "fileName"); };
-        await func.Should().ThrowAsync<Exception>();
+        Assert.CatchAsync<Exception>(async () => await func());
     }
 
     [Test]
@@ -171,7 +171,7 @@ public class AzureBlobStorageClientTests
         
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadStringAsync(containerName, blobName);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -189,7 +189,7 @@ public class AzureBlobStorageClientTests
         
         var azureBlobStorageClient = GetClient();
         var result = await azureBlobStorageClient.DownloadStringAsync(containerName, blobName);
-        result.Should().BeEquivalentTo(testData);
+        Assert.That(result, Is.EqualTo(testData));
     }
 
     [Test]
@@ -216,7 +216,7 @@ public class AzureBlobStorageClientTests
             .ThrowsAsync(new RequestFailedException(404, "BlobNotFound", "BlobNotFound", null));
 
         var action = () => GetClient().DeleteAsync(containerName, dirName, blobName);
-        await action.Should().NotThrowAsync();
+        Assert.DoesNotThrowAsync(async () => await action());
     }
 
     [Test]
@@ -227,7 +227,7 @@ public class AzureBlobStorageClientTests
             .ThrowsAsync(new RequestFailedException(400, "InvalidOperation", "InvalidOperation", null));
 
         var action = () => GetClient().DeleteAsync(containerName, dirName, blobName);
-        await action.Should().ThrowAsync<ExternalServiceUnavailableException>();
+        Assert.ThrowsAsync<ExternalServiceUnavailableException>(async () => await action());
     }
 
     [Test]
@@ -249,7 +249,7 @@ public class AzureBlobStorageClientTests
             .ThrowsAsync(new RequestFailedException(400, "InvalidOperation", "InvalidOperation", null));
 
         var action = () => GetClient().ExistsAsync(containerName, blobName);
-        await action.Should().ThrowAsync<ExternalServiceUnavailableException>();
+        Assert.ThrowsAsync<ExternalServiceUnavailableException>(async () => await action());
     }
 
     [Test]
@@ -268,15 +268,15 @@ public class AzureBlobStorageClientTests
             .ThrowsAsync(new RequestFailedException(400, "InvalidOperation", "InvalidOperation", null));
 
         var action = () => GetClient().SetCacheControlAsync(containerName, blobName, "cacheControl");
-        await action.Should().ThrowAsync<ExternalServiceUnavailableException>();
+        Assert.ThrowsAsync<ExternalServiceUnavailableException>(async () => await action());
     }
 
     [Test]
     public async Task UploadAsync_should_throw_exception_when_stream_null()
     {
         var action = () => GetClient().UploadAsync(containerName, blobName, null as Stream, "text/plain");
-        var exception = await action.Should().ThrowAsync<ArgumentNullException>();
-        exception.Which.ParamName.Should().Be("content");
+        var exception = Assert.ThrowsAsync<ArgumentNullException>(async () => await action());
+        Assert.That(exception!.ParamName, Is.EqualTo("content"));
     }
 
     private AzureBlobStorageClient GetClient() => new(blobServiceClient!.Object, this.logger!.Object);

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageFeedDAOTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageFeedDAOTests.cs
@@ -32,7 +32,7 @@ public class AzureBlobStorageFeedDAOTests
         var result = await GetDao().LoadBaseFeedAsync();
         azureBlobStorageClient!.Verify(x => x.DownloadStringAsync("rssfeeds", "baseFeed.xml"));
         var newXml = result.ToArray().GenerateXml();
-        newXml.Should().Be(this.baseFeed);
+        Assert.That(newXml, Is.EqualTo(this.baseFeed));
     }
 
     private AzureBlobStorageFeedDao GetDao()

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureBlobStorageTorrentFileDaoTests
@@ -32,7 +32,7 @@ public class AzureBlobStorageTorrentFileDaoTests
         this.azureBlobStorageClient.Setup(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent")).ReturnsAsync(null as Stream);
         var result = await dao.LoadBaseFileAsync(torrentId);
         this.azureBlobStorageClient.Verify(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent"), Times.Once);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -43,8 +43,8 @@ public class AzureBlobStorageTorrentFileDaoTests
         this.azureBlobStorageClient.Setup(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent")).ReturnsAsync(new MemoryStream());
         var result = await dao.LoadBaseFileAsync(torrentId);
         this.azureBlobStorageClient.Verify(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent"), Times.Once);
-        result.Should().NotBeNull();
-        string.Equals(result!.FileName, $"{torrentId}.torrent").Should().BeTrue();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(string.Equals(result!.FileName, $"{torrentId}.torrent"), Is.True);
     }
     
     [Test]

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageEpisodeDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageEpisodeDaoTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureTableStorageEpisodeDaoTests : AzureTableStorageDaoTestsBase<AzureTableStorageEpisodeDao>
@@ -28,7 +28,9 @@ public class AzureTableStorageEpisodeDaoTests : AzureTableStorageDaoTestsBase<Az
         tableClient!.Setup(x => x.UpsertEntityAsync(It.IsAny<EpisodeTableEntity>(), TableUpdateMode.Merge, default))
             .ThrowsAsync(new RequestFailedException(500, "Internal Server Error"));
         var action = async () => await GetDao().SaveAsync(episode);
-        await action.Should().ThrowAsync<ExternalServiceUnavailableException>().WithMessage("Azure Table Storage is not accessible");
+        Assert.That(
+            Assert.ThrowsAsync<ExternalServiceUnavailableException>(async () => await action())!.Message,
+            Is.EqualTo("Azure Table Storage is not accessible"));
     }
 
     [Test]

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageSeriesDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageSeriesDaoTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureTableStorageSeriesDaoTests : AzureTableStorageDaoTestsBase<AzureTableStorageSeriesDao>
@@ -51,7 +51,7 @@ public class AzureTableStorageSeriesDaoTests : AzureTableStorageDaoTestsBase<Azu
             .Setup(x => x.GetEntityAsync<SeriesTableEntity>("Name", "Name", null, default))
             .Throws(new RequestFailedException(404, "ResourceNotFound", "ResourceNotFound", null));
         var series = await GetDao().LoadAsync("Name");
-        series.Should().BeNull();
+        Assert.That(series, Is.Null);
     }
 
     [Test]
@@ -66,7 +66,7 @@ public class AzureTableStorageSeriesDaoTests : AzureTableStorageDaoTestsBase<Azu
             .Setup(x => x.GetEntityAsync<SeriesTableEntity>(entity.Name, entity.Name, null, default))
             .ReturnsAsync(new TestResponse<SeriesTableEntity>(entity));
         var loadedSeries = await GetDao().LoadAsync(entity.Name);
-        (loadedSeries?.Name).Should().Be(entity.Name);
+        Assert.That(loadedSeries?.Name, Is.EqualTo(entity.Name));
     }
 
     [Test]
@@ -80,7 +80,7 @@ public class AzureTableStorageSeriesDaoTests : AzureTableStorageDaoTestsBase<Azu
                 default))
             .Throws(new RequestFailedException(404, "ResourceNotFound", "ResourceNotFound", null));
         var result = await GetDao().LoadAsync();
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -102,11 +102,9 @@ public class AzureTableStorageSeriesDaoTests : AzureTableStorageDaoTestsBase<Azu
             .Returns(expected);
         
         var result = await GetDao().LoadAsync();
-        (result is { Length: 2 } &&
+        Assert.That(result is { Length: 2 } &&
             result.Any(x => x.Name == "A") && 
-            result.Any(x => x.Name == "B"))
-.Should().BeTrue(
-        );
+            result.Any(x => x.Name == "B"), Is.True);
     }
 
     [Test]

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageSubscriptionDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageSubscriptionDaoTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBase<AzureTableStorageSubscriptionDao>
@@ -8,7 +8,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
     {
         var result = await GetDao().LoadAsync(string.Empty);
         tableClient!.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Never);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -16,7 +16,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
     {
         var result = await GetDao().LoadAsync(null!);
         tableClient!.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Never);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -27,7 +27,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
             .Returns(new TestAsyncPageable<SubscriptionTableEntity>([]));
         var result = await GetDao().LoadAsync(Guid.NewGuid().ToString());
         tableClient.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Once);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -45,7 +45,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
             .Returns(new TestAsyncPageable<SubscriptionTableEntity>([entity]));
         var result = await GetDao().LoadAsync(userId);
         tableClient.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Once);
-        result.Should().BeEquivalentTo([new Subscription(entity.PartitionKey, entity.Quality)]);
+        Assert.That(result, Is.EqualTo([new Subscription(entity.PartitionKey, entity.Quality)]));
     }
 
     [Test]
@@ -56,7 +56,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
             .Throws(new RequestFailedException(404, "ResourceNotFound", "ResourceNotFound", null));
         var result = await GetDao().LoadAsync(Guid.NewGuid().ToString());
         tableClient.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Once);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
     {
         var result = await GetDao().LoadUsersIdsAsync("A", string.Empty);
         tableClient!.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Never);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -72,7 +72,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
     {
         var result = await GetDao().LoadUsersIdsAsync(string.Empty, "User123");
         tableClient!.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Never);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -91,7 +91,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
             .Returns(new TestAsyncPageable<SubscriptionTableEntity>([entity]));
         var result = await GetDao().LoadUsersIdsAsync(seriesName, userId);
         tableClient.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Once);
-        result.Should().BeEquivalentTo([userId]);
+        Assert.That(result, Is.EqualTo([userId]));
     }
 
     [Test]
@@ -102,7 +102,7 @@ public class AzureTableStorageSubscriptionDaoTests : AzureTableStorageDaoTestsBa
             .Throws(new RequestFailedException(404, "ResourceNotFound", "ResourceNotFound", null));
         var result = await GetDao().LoadUsersIdsAsync("SeriesName", "User123");
         tableClient.Verify(x => x.QueryAsync<SubscriptionTableEntity>(It.IsAny<Expression<Func<SubscriptionTableEntity, bool>>>(), null, null, default), Times.Once);
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageUserDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureTableStorageUserDaoTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmMonitoring.DAO.Azure.Tests;
+namespace LostFilmMonitoring.DAO.Azure.Tests;
 
 [ExcludeFromCodeCoverage]
 public class AzureTableStorageUserDaoTests : AzureTableStorageDaoTestsBase<AzureTableStorageUserDao>
@@ -10,7 +10,7 @@ public class AzureTableStorageUserDaoTests : AzureTableStorageDaoTestsBase<Azure
             .Setup(x => x.QueryAsync<UserTableEntity>(null as string, null, null, default))
             .Returns(new TestAsyncPageable<UserTableEntity>([]));
         var result = await GetDao().LoadAsync();
-        result.Should().Equal([]);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -35,7 +35,7 @@ public class AzureTableStorageUserDaoTests : AzureTableStorageDaoTestsBase<Azure
             .Setup(x => x.QueryAsync<UserTableEntity>(null as string, null, null, default))
             .Returns(new TestAsyncPageable<UserTableEntity>(users));
         var result = await GetDao().LoadAsync();
-        result.Should().BeEquivalentTo(expected);
+        Assert.That(result, Is.EqualTo(expected));
     }
 
     [Test]
@@ -54,7 +54,7 @@ public class AzureTableStorageUserDaoTests : AzureTableStorageDaoTestsBase<Azure
             .Throws(new RequestFailedException(404, "ResourceNotFound", "ResourceNotFound", null));
 
         var result = await GetDao().LoadAsync("UserId");
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -71,9 +71,9 @@ public class AzureTableStorageUserDaoTests : AzureTableStorageDaoTestsBase<Azure
             .ReturnsAsync(new TestResponse<UserTableEntity>(userTableEntity));
 
         var result = await GetDao().LoadAsync("UserId");
-        (result is { Id: var id, TrackerId: var trackerId } &&
+        Assert.That(result is { Id: var id, TrackerId: var trackerId } &&
             id == userTableEntity.RowKey &&
-            trackerId == userTableEntity.TrackerId).Should().BeTrue();
+            trackerId == userTableEntity.TrackerId, Is.True);
     }
 
     protected override AzureTableStorageUserDao GetDao()

--- a/LostFilmMonitoring.DAO.Azure.Tests/LostFilmMonitoring.DAO.Azure.Tests.csproj
+++ b/LostFilmMonitoring.DAO.Azure.Tests/LostFilmMonitoring.DAO.Azure.Tests.csproj
@@ -19,11 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.6.1" />

--- a/LostFilmMonitoring.DAO.Azure.Tests/Usings.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/Usings.cs
@@ -1,10 +1,9 @@
-﻿global using NUnit.Framework;
+global using NUnit.Framework;
 global using Moq;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Reflection;
 global using Azure.Storage.Blobs;
 global using Azure.Storage.Blobs.Models;
-global using FluentAssertions;
 global using Azure;
 global using Azure.Core;
 global using Azure.Data.Tables;

--- a/LostFilmMonitoring.TorrentFileImpl.Tests/LostFilmMonitoring.TorrentFileImpl.Tests.csproj
+++ b/LostFilmMonitoring.TorrentFileImpl.Tests/LostFilmMonitoring.TorrentFileImpl.Tests.csproj
@@ -16,11 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />

--- a/LostFilmMonitoring.TorrentFileImpl.Tests/TorrentFileHelperTests.cs
+++ b/LostFilmMonitoring.TorrentFileImpl.Tests/TorrentFileHelperTests.cs
@@ -16,8 +16,8 @@ internal class TorrentFileHelperTests
     {
         using var stream = GetTorrentStream();
         var result = this.helper.Parse(stream);
-        result.Should().NotBeNull();
-        result.Should().BeAssignableTo<IParsedTorrent>();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.AssignableTo<IParsedTorrent>());
     }
 
     [Test]
@@ -25,7 +25,7 @@ internal class TorrentFileHelperTests
     {
         using var stream = GetTorrentStream();
         var result = this.helper.Parse(stream);
-        result.DisplayName.Should().Be("The.Flash.S08E13.720p.rus.LostFilm.TV.mp4");
+        Assert.That(result.DisplayName, Is.EqualTo("The.Flash.S08E13.720p.rus.LostFilm.TV.mp4"));
     }
 
     [Test]
@@ -33,7 +33,7 @@ internal class TorrentFileHelperTests
     {
         using var stream = GetTorrentStream();
         this.helper.Parse(stream);
-        stream.Position.Should().Be(0);
+        Assert.That(stream.Position, Is.EqualTo(0));
     }
 
     [Test]
@@ -42,7 +42,7 @@ internal class TorrentFileHelperTests
         using var stream = GetTorrentStream();
         var result = this.helper.Parse(stream);
         var torrentFile = result.ToTorrentFile(["http://tracker.example.com/announce"]);
-        torrentFile.Should().NotBeNull();
+        Assert.That(torrentFile, Is.Not.Null);
     }
 
     [Test]
@@ -51,7 +51,7 @@ internal class TorrentFileHelperTests
         using var stream = GetTorrentStream();
         var parsedTorrent = this.helper.Parse(stream);
         var torrentFile = parsedTorrent.ToTorrentFile(["http://tracker.example.com/announce"]);
-        torrentFile.FileName.Should().Be("The.Flash.S08E13.720p.rus.LostFilm.TV.mp4");
+        Assert.That(torrentFile.FileName, Is.EqualTo("The.Flash.S08E13.720p.rus.LostFilm.TV.mp4"));
     }
 
     [Test]
@@ -60,7 +60,7 @@ internal class TorrentFileHelperTests
         using var stream = GetTorrentStream();
         var parsedTorrent = this.helper.Parse(stream);
         var torrentFile = parsedTorrent.ToTorrentFile(["http://tracker.example.com/announce"]);
-        torrentFile.Stream.Length.Should().BeGreaterThan(0);
+        Assert.That(torrentFile.Stream.Length, Is.GreaterThan(0));
     }
 
     [Test]
@@ -76,8 +76,8 @@ internal class TorrentFileHelperTests
         using var resultStream = torrentFile.Stream;
         using var reader = new StreamReader(resultStream);
         var content = reader.ReadToEnd();
-        content.Should().Contain(announce1);
-        content.Should().Contain(announce2);
+        Assert.That(content, Does.Contain(announce1));
+        Assert.That(content, Does.Contain(announce2));
     }
 
     [Test]
@@ -95,8 +95,8 @@ internal class TorrentFileHelperTests
             results.Add(torrentFile);
         });
 
-        results.Should().HaveCount(10);
-        results.Should().AllSatisfy(f => f.FileName.Should().Be("The.Flash.S08E13.720p.rus.LostFilm.TV.mp4"));
+        Assert.That(results, Has.Count.EqualTo(10));
+        Assert.That(results.All(f => f.FileName == "The.Flash.S08E13.720p.rus.LostFilm.TV.mp4"), Is.True);
     }
 
     private static Stream GetTorrentStream()

--- a/LostFilmMonitoring.TorrentFileImpl.Tests/Usings.cs
+++ b/LostFilmMonitoring.TorrentFileImpl.Tests/Usings.cs
@@ -1,5 +1,4 @@
 global using NUnit.Framework;
-global using FluentAssertions;
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO;
 global using LostFilmMonitoring.TorrentFileImpl;

--- a/LostFilmTV.Client.Tests/AGENTS.md
+++ b/LostFilmTV.Client.Tests/AGENTS.md
@@ -24,9 +24,9 @@ public void ReteOrgRssFeed_should_parse_valid_feed()
     var items = feed.LoadFeedItems(xml);
     
     // Assert
-    items.Should().HaveCount(expected);
-    items[0].Title.Should().Contain("Series Name");
-    items[0].Quality.Should().Be("1080");
+    Assert.That(items, Has.Count.EqualTo(expected));
+    Assert.That(items[0].Title, Does.Contain("Series Name"));
+    Assert.That(items[0].Quality, Is.EqualTo("1080"));
 }
 ```
 

--- a/LostFilmTV.Client.Tests/LostFilmClientTests.cs
+++ b/LostFilmTV.Client.Tests/LostFilmClientTests.cs
@@ -1,4 +1,4 @@
-﻿namespace LostFilmTV.Client.Tests;
+namespace LostFilmTV.Client.Tests;
 
 [TestFixture]
 [ExcludeFromCodeCoverage]
@@ -22,21 +22,21 @@ public class LostFilmClientTests
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new LostFilmClient(null!, this.httpClientFactory.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_createScope_null()
     {
         var action = () => new LostFilmClient(new Mock<ILogger>().Object, this.httpClientFactory.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_httpClientFactory_null()
     {
         var action = () => new LostFilmClient(this.logger.Object, null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("httpClientFactory");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("httpClientFactory"));
     }
 
     [Test]
@@ -50,7 +50,7 @@ public class LostFilmClientTests
 
         var client = new LostFilmClient(logger.Object, httpClientFactory.Object);
         var result = await client.DownloadTorrentFileAsync("uid", "usess", torrentFileId);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class LostFilmClientTests
 
         var client = new LostFilmClient(logger.Object, httpClientFactory.Object);
         var result = await client.DownloadTorrentFileAsync("uid", "usess", torrentFileId);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -78,7 +78,7 @@ public class LostFilmClientTests
 
         var client = new LostFilmClient(logger.Object, httpClientFactory.Object);
         var result = await client.DownloadTorrentFileAsync("uid", "usess", torrentFileId);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     [Test]
@@ -91,7 +91,7 @@ public class LostFilmClientTests
 
         var client = new LostFilmClient(logger.Object, httpClientFactory.Object);
         var result = await client.DownloadTorrentFileAsync("uid", "usess", torrentFileId);
-        result.Should().BeNull();
+        Assert.That(result, Is.Null);
     }
 
     private static byte[] ReadFully(Stream input)

--- a/LostFilmTV.Client.Tests/LostFilmTV.Client.Tests.csproj
+++ b/LostFilmTV.Client.Tests/LostFilmTV.Client.Tests.csproj
@@ -32,7 +32,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="8.10.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.6.1" />

--- a/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
+++ b/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
@@ -23,21 +23,21 @@ public class ReteOrgRssFeedTests
     public void Constructor_should_throw_exception_when_logger_null()
     {
         var action = () => new ReteOrgRssFeed(null!, this.httpClientFactory.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_createScope_null()
     {
         var action = () => new ReteOrgRssFeed(new Mock<ILogger>().Object, this.httpClientFactory.Object);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_httpClientFactory_null()
     {
         var action = () => new ReteOrgRssFeed(this.logger.Object, null!);
-        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("httpClientFactory");
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("httpClientFactory"));
     }
 
     [Test]
@@ -47,8 +47,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Respond("application/xml", Helper.GetEmbeddedResource("LostFilmTV.Client.Tests.TestData.BaseFeed1.xml"));
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().NotBeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Not.Empty);
     }
 
     [Test]
@@ -58,8 +58,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Respond("application/xml", string.Empty);
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -69,8 +69,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Throw(new TaskCanceledException());
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -80,8 +80,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Throw(new IOException());
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -91,8 +91,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Throw(new Exception());
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -102,8 +102,8 @@ public class ReteOrgRssFeedTests
             .When(HttpMethod.Get, "https://insearch.site/rssdd.xml")
             .Respond("application/xml", "BROKEN RSS DATA");
         var result = await GetService().LoadFeedItemsAsync();
-        result.Should().NotBeNull();
-        result.Should().BeEmpty();
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.Empty);
     }
 
     [Test]
@@ -128,9 +128,9 @@ public class ReteOrgRssFeedTests
 
         var result = await GetService().LoadFeedItemsAsync();
 
-        result.Should().NotBeNull();
-        result.Should().HaveCount(1);
-        result!.First().Link.Should().Be("http://n.tracktor.site/rssdownloader.php?id=51236&source=test");
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result!.First().Link, Is.EqualTo("http://n.tracktor.site/rssdownloader.php?id=51236&source=test"));
     }
 
     private ReteOrgRssFeed GetService() => new(this.logger.Object, this.httpClientFactory.Object);

--- a/LostFilmTV.Client.Tests/Usings.cs
+++ b/LostFilmTV.Client.Tests/Usings.cs
@@ -1,4 +1,4 @@
-﻿global using System;
+global using System;
 global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
 global using System.Xml.Linq;
@@ -10,7 +10,6 @@ global using LostFilmTV.Client.RssFeed;
 global using Moq;
 global using System.IO;
 global using System.Reflection;
-global using FluentAssertions;
 global using System.Threading.Tasks;
 global using RichardSzalay.MockHttp;
 global using System.Text;


### PR DESCRIPTION
## Summary

- Replaced FluentAssertions usages in test projects with NUnit assertions.
- Removed FluentAssertions package references and global usings from test projects.
- Added a small validation-error assertion helper for repeated dictionary checks.

## Validation

- `dotnet test .\LostFilmMonitoring.sln --no-restore`
- `rg -n 'FluentAssertions|Should\(|\.Should\(|PackageReference Include="FluentAssertions|\?\?\?\?' -S .`