### PR TITLE
Fix SonarQube issues for lAnubisl_LostFilmTorrentsFeed

### DIFF
--- a/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs
@@ -122,12 +122,12 @@ public class DownloadCoverImagesCommandTests
 
         await command.ExecuteAsync();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(callOrder, Has.Count.EqualTo(2));
             Assert.That(callOrder[0], Is.EqualTo(series1));
             Assert.That(callOrder[1], Is.EqualTo(series2));
-        });
+        }
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs
@@ -41,10 +41,13 @@ internal class GetUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(null);
-        Assert.That(response.TrackerId, Is.Null);
-        Assert.That(response.ValidationResult, Is.Not.Null);
-        Assert.That(response.ValidationResult.IsValid, Is.False);
-        TestAssert.HasSingleError(response.ValidationResult.Errors, "model", ErrorMessages.RequestNull);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.TrackerId, Is.Null);
+            Assert.That(response.ValidationResult, Is.Not.Null);
+            Assert.That(response.ValidationResult.IsValid, Is.False);
+            TestAssert.HasSingleError(response.ValidationResult.Errors, "model", ErrorMessages.RequestNull);
+        }
     }
 
     [Test]
@@ -52,10 +55,13 @@ internal class GetUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new GetUserRequestModel());
-        Assert.That(response.TrackerId, Is.Null);
-        Assert.That(response.ValidationResult, Is.Not.Null);
-        Assert.That(response.ValidationResult.IsValid, Is.False);
-        TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.FieldEmpty, nameof(GetUserRequestModel.UserId)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.TrackerId, Is.Null);
+            Assert.That(response.ValidationResult, Is.Not.Null);
+            Assert.That(response.ValidationResult.IsValid, Is.False);
+            TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.FieldEmpty, nameof(GetUserRequestModel.UserId)));
+        }
     }
 
     [Test]
@@ -65,10 +71,13 @@ internal class GetUserCommandTests
         this.userDao!.Setup(x => x.LoadAsync(It.IsAny<string>())).ReturnsAsync(null as User);
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new GetUserRequestModel { UserId = testUserIdValue });
-        Assert.That(response.TrackerId, Is.Null);
-        Assert.That(response.ValidationResult, Is.Not.Null);
-        Assert.That(response.ValidationResult.IsValid, Is.False);
-        TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.UserDoesNotExist, nameof(GetUserRequestModel.UserId), testUserIdValue));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.TrackerId, Is.Null);
+            Assert.That(response.ValidationResult, Is.Not.Null);
+            Assert.That(response.ValidationResult.IsValid, Is.False);
+            TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(GetUserRequestModel.UserId), string.Format(ErrorMessages.UserDoesNotExist, nameof(GetUserRequestModel.UserId), testUserIdValue));
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Fix SonarQube issues for `lAnubisl_LostFilmTorrentsFeed`

| Field | Value |
| --- | --- |
| SonarQube project | `lAnubisl_LostFilmTorrentsFeed` |
| SonarQube branch | `master` |
| Base branch | `master` |
| Generated branch | `copilot/sonar-fixes/lAnubisl_LostFilmTorrentsFeed/20260629142140` |
| Issues selected | `5` |
| Issues attempted | `5` |

## AI Usage (Copilot CLI `/usage`)

```text
● Checking my documentation
  └ # GitHub Copilot CLI Documentation

**Usage Statistics** (Current Session)

```
┌─ Context Window ─────────────────────────────────────────────────┐
│ Total Budget:    200,000 tokens                                  │
│ Used:            ~31,000 tokens                                  │
│ Remaining:       ~169,000 tokens                                 │
│ Session Length:  ~1 minute                                       │
└──────────────────────────────────────────────────────────────────┘

Task Execution:
  ✓ 2 files edited (minimal changes)
  ✓ 5 SonarQube issues fixed
  ✓ Multiple parallel read operations
  ✓ No build/test overhead (permission constraints)

Efficiency:
  • Focused approach - no unnecessary exploration
  • Parallel tool calls - batched independent operations
  • Targeted edits - surgical changes only
  • Direct problem-solving
```

For detailed context usage, use: **`/context`**
```

## Issue List
- [AZ8TH__vRs-9Ay15yBlZ](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8TH__vRs-9Ay15yBlZ&open=AZ8TH__vRs-9Ay15yBlZ) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs` line `125`
- [AZ8BZ2q3-1jWpY_LduWn](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8BZ2q3-1jWpY_LduWn&open=AZ8BZ2q3-1jWpY_LduWn) `external_roslyn:NUnit2045` `LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs` line `not specified`
- [AZ8BZ2rc-1jWpY_LduWq](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8BZ2rc-1jWpY_LduWq&open=AZ8BZ2rc-1jWpY_LduWq) `external_roslyn:NUnit2045` `LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs` line `44`
- [AZ8BZ2rc-1jWpY_LduWr](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8BZ2rc-1jWpY_LduWr&open=AZ8BZ2rc-1jWpY_LduWr) `external_roslyn:NUnit2045` `LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs` line `55`
- [AZ8BZ2rc-1jWpY_LduWs](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8BZ2rc-1jWpY_LduWs&open=AZ8BZ2rc-1jWpY_LduWs) `external_roslyn:NUnit2045` `LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs` line `68`

## Changed Files
- `LostFilmMonitoring.BLL.Tests/Commands/DownloadCoverImagesCommandTests.cs`
- `LostFilmMonitoring.BLL.Tests/Commands/GetUserCommandTests.cs`

## Resolution Summary
- `AZ8TH__vRs-9Ay15yBlZ`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8BZ2q3-1jWpY_LduWn`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8BZ2rc-1jWpY_LduWq`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8BZ2rc-1jWpY_LduWr`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8BZ2rc-1jWpY_LduWs`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.

## Skipped Or Not Fixed
- The automation cannot conclusively verify SonarQube closure until SonarQube re-analyzes this branch.

## Review Notes
- These changes were generated using GitHub Copilot CLI from selected SonarQube issue context.
- Human review is required before merge.
- Validation is delegated to the repository's pull request checks.
- Verify that no unrelated behavior, formatting, generated files, or security-sensitive values were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated several unit tests to use the newer scoped multiple-assertion pattern.
  * Preserved existing validation and call-order expectations for download and user-related command scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->