### PR TITLE
Fix SonarQube issues for lAnubisl_LostFilmTorrentsFeed

### DIFF
--- a/LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs
@@ -73,13 +73,13 @@ internal class SaveUserCommandTests
     {
         var command = CreateCommand();
         var response = await command.ExecuteAsync(new EditUserRequestModel());
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(response.UserId, Is.Null);
             Assert.That(response.ValidationResult, Is.Not.Null);
             Assert.That(response.ValidationResult.IsValid, Is.False);
             TestAssert.HasSingleError(response.ValidationResult.Errors, nameof(EditUserRequestModel.TrackerId), string.Format(ErrorMessages.FieldEmpty, nameof(EditUserRequestModel.TrackerId)));
-        });
+        }
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
@@ -295,7 +295,7 @@ public class UpdateFeedsCommandTests
         await command.ExecuteAsync();
 
         // Verify series is saved with initial empty ID
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(savedSeries.Any(x => x.Id == Guid.Empty), Is.True);
             // Verify series is saved with final properties
@@ -307,7 +307,7 @@ public class UpdateFeedsCommandTests
              && x.LastEpisodeTorrentLink1080 == "http://n.tracktor.site/rssdownloader.php?id=51438"
              && x.LastEpisodeTorrentLinkMP4 == "http://n.tracktor.site/rssdownloader.php?id=51439"
              && x.LastEpisodeTorrentLinkSD == "http://n.tracktor.site/rssdownloader.php?id=51437"), Is.True);
-        });
+        }
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
@@ -21,13 +21,13 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
         var service = GetService();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(service.BaseUID, Is.EqualTo("BASELINKUID"));
             Assert.That(service.BaseUSESS, Is.EqualTo("BASEFEEDCOOKIE"));
             Assert.That(service.BaseUrl, Is.EqualTo("BASEURL"));
             Assert.That(service.GetTorrentAnnounceList("USERID"), Is.EqualTo(["#1USERID", "#2USERID", "#3USERID"]));
-        });
+        }
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL.Tests/TestAssert.cs
+++ b/LostFilmMonitoring.BLL.Tests/TestAssert.cs
@@ -5,11 +5,11 @@ internal static class TestAssert
 {
     public static void HasSingleError(Dictionary<string, string> errors, string key, string value)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(errors, Has.Count.EqualTo(1));
             Assert.That(errors.Single().Key, Is.EqualTo(key));
             Assert.That(errors.Single().Value, Is.EqualTo(value));
-        });
+        }
     }
 }

--- a/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
@@ -97,11 +97,11 @@ public class EditSubscriptionRequestModelValidatorTests
         this.seriesDao!.Setup(x => x.LoadAsync()).ReturnsAsync([testSeries]);
         this.userDao!.Setup(x => x.LoadAsync("userId")).ReturnsAsync(new User(string.Empty, string.Empty));
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem() { SeriesId = "11111111-1111-1111-1111-111111111111", Quality = "SD" }] });
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.IsValid, Is.True);
             Assert.That(result.Errors, Is.Empty);
-        });
+        }
     }
 
     private EditSubscriptionRequestModelValidator GetService() => new(

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs
@@ -75,12 +75,12 @@ public class AzureBlobStorageClientTests
         // Ensure there is no UTF-8 BOM at the start
         if (bytes.Length >= 3)
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(bytes[0], Is.Not.EqualTo((byte)0xEF));
                 Assert.That(bytes[1], Is.Not.EqualTo((byte)0xBB));
                 Assert.That(bytes[2], Is.Not.EqualTo((byte)0xBF));
-            });
+            }
         }
     }
 

--- a/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs
@@ -43,11 +43,11 @@ public class AzureBlobStorageTorrentFileDaoTests
         this.azureBlobStorageClient.Setup(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent")).ReturnsAsync(new MemoryStream());
         var result = await dao.LoadBaseFileAsync(torrentId);
         this.azureBlobStorageClient.Verify(x => x.DownloadAsync("basetorrents", $"{torrentId}.torrent"), Times.Once);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.Not.Null);
             Assert.That(string.Equals(result!.FileName, $"{torrentId}.torrent"), Is.True);
-        });
+        }
     }
     
     [Test]

--- a/LostFilmTV.Client.Tests/FeedItemResponseTests.cs
+++ b/LostFilmTV.Client.Tests/FeedItemResponseTests.cs
@@ -23,11 +23,11 @@ public class FeedItemResponseTests
             </item>");
         ReteOrgFeedItemResponse feedItemResponse;
         var ok = ReteOrgFeedItemResponse.TryParseFromXElement(el, out feedItemResponse);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ok, Is.True);
             Assert.That(feedItemResponse!.TorrentId, Is.EqualTo(expected));
-        });
+        }
     }
 
     [Test]
@@ -48,16 +48,19 @@ public class FeedItemResponseTests
         var ok = ReteOrgFeedItemResponse.TryParseFromXElement(el, out feedItemResponse);
         if (expected == null)
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(ok, Is.False);
                 Assert.That(feedItemResponse, Is.Null);
-            });
+            }
         }
         else
         {
-            Assert.That(ok, Is.True);
-            Assert.That(feedItemResponse!.SeriesName, Is.EqualTo(expected));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ok, Is.True);
+                Assert.That(feedItemResponse!.SeriesName, Is.EqualTo(expected));
+            }
         }
     }
 


### PR DESCRIPTION
## Fix SonarQube issues for `lAnubisl_LostFilmTorrentsFeed`

| Field | Value |
| --- | --- |
| SonarQube project | `lAnubisl_LostFilmTorrentsFeed` |
| SonarQube branch | `master` |
| Base branch | `master` |
| Generated branch | `copilot/sonar-fixes/lAnubisl_LostFilmTorrentsFeed/20260629172849` |
| Issues selected | `10` |
| Issues attempted | `10` |

## Copilot Session Summary

```text
Changes    +23 -20
AI Credits 12.7 (1m 15s)
Tokens     ↑ 396.0k (360.4k cached, 35.5k written) • ↓ 9.3k (1.4k reasoning)
```

## Issue List
- [AZ8Uam2Ky35bZZY3M6xM](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam2Ky35bZZY3M6xM&open=AZ8Uam2Ky35bZZY3M6xM) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs` line `76`
- [AZ8Uam2Cy35bZZY3M6xL](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam2Cy35bZZY3M6xL&open=AZ8Uam2Cy35bZZY3M6xL) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs` line `298`
- [AZ8Uam2Uy35bZZY3M6xN](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam2Uy35bZZY3M6xN&open=AZ8Uam2Uy35bZZY3M6xN) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs` line `24`
- [AZ8Uam2hy35bZZY3M6xP](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam2hy35bZZY3M6xP&open=AZ8Uam2hy35bZZY3M6xP) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/TestAssert.cs` line `8`
- [AZ8Uam2ay35bZZY3M6xO](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam2ay35bZZY3M6xO&open=AZ8Uam2ay35bZZY3M6xO) `external_roslyn:NUnit2056` `LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs` line `100`
- [AZ8Uam0ty35bZZY3M6xH](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam0ty35bZZY3M6xH&open=AZ8Uam0ty35bZZY3M6xH) `external_roslyn:NUnit2056` `LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs` line `78`
- [AZ8Uam01y35bZZY3M6xI](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam01y35bZZY3M6xI&open=AZ8Uam01y35bZZY3M6xI) `external_roslyn:NUnit2056` `LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs` line `46`
- [AZ8Uam1zy35bZZY3M6xJ](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam1zy35bZZY3M6xJ&open=AZ8Uam1zy35bZZY3M6xJ) `external_roslyn:NUnit2056` `LostFilmTV.Client.Tests/FeedItemResponseTests.cs` line `26`
- [AZ8Uam1zy35bZZY3M6xK](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8Uam1zy35bZZY3M6xK&open=AZ8Uam1zy35bZZY3M6xK) `external_roslyn:NUnit2056` `LostFilmTV.Client.Tests/FeedItemResponseTests.cs` line `51`
- [AZ6VQfBZX2fRQ0gEyiMz](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ6VQfBZX2fRQ0gEyiMz&open=AZ6VQfBZX2fRQ0gEyiMz) `external_roslyn:NUnit2045` `LostFilmTV.Client.Tests/FeedItemResponseTests.cs` line `59`

## Changed Files
- `LostFilmMonitoring.BLL.Tests/Commands/SaveUserCommandTests.cs`
- `LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs`
- `LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs`
- `LostFilmMonitoring.BLL.Tests/TestAssert.cs`
- `LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs`
- `LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageClientTests.cs`
- `LostFilmMonitoring.DAO.Azure.Tests/AzureBlobStorageTorrentFileDaoTests.cs`
- `LostFilmTV.Client.Tests/FeedItemResponseTests.cs`

## Resolution Summary
- `AZ8Uam2Ky35bZZY3M6xM`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam2Cy35bZZY3M6xL`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam2Uy35bZZY3M6xN`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam2hy35bZZY3M6xP`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam2ay35bZZY3M6xO`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam0ty35bZZY3M6xH`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam01y35bZZY3M6xI`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam1zy35bZZY3M6xJ`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8Uam1zy35bZZY3M6xK`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ6VQfBZX2fRQ0gEyiMz`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.

## Skipped Or Not Fixed
- The automation cannot conclusively verify SonarQube closure until SonarQube re-analyzes this branch.

## Review Notes
- These changes were generated using GitHub Copilot CLI from selected SonarQube issue context.
- Human review is required before merge.
- Validation is delegated to the repository's pull request checks.
- Verify that no unrelated behavior, formatting, generated files, or security-sensitive values were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suites to use a newer grouped-assertion pattern for clearer failure reporting.
  * Kept all existing validation checks unchanged, including response values, validation errors, file content checks, and parsed feed data.
  * Improved consistency across unit tests without changing product behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->