### PR TITLE
Fix SonarQube issues for lAnubisl_LostFilmTorrentsFeed

### DIFF
--- a/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoring.AzureInfrastructure.csproj
+++ b/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoring.AzureInfrastructure.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="Pulumi" Version="3.106.2" />
     <PackageReference Include="Pulumi.AzureNative" Version="3.19.0" />
     <PackageReference Include="Pulumi.Cloudflare" Version="6.17.0" />

--- a/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
+++ b/LostFilmMonitoring.AzureInfrastructure/LostFilmMonitoringStack.cs
@@ -447,6 +447,7 @@ public class LostFilmMonitoringStack : Pulumi.Stack
                     { EnvironmentVariables.BaseLinkUID, config.RequireSecret("baselinkuid") },
                     { EnvironmentVariables.TorrentTrackers, config.Require("torrenttrackers") },
                     { EnvironmentVariables.TmdbApiKey, config.RequireSecret("tmdbapikey") },
+                    { EnvironmentVariables.RssFeedUrl, config.Require("rssfeedurl") }
                 }),
                 Cors = new Azure.Web.Inputs.CorsSettingsArgs
                 {

--- a/LostFilmMonitoring.AzureInfrastructure/Pulumi.dev.yaml
+++ b/LostFilmMonitoring.AzureInfrastructure/Pulumi.dev.yaml
@@ -1,6 +1,7 @@
 config:
   LostFilmMonitoring.AzureInfrastructure:location: westeurope
   LostFilmMonitoring.AzureInfrastructure:baseurl: https://datalostfilmfeeddev.byalex.dev
+  LostFilmMonitoring.AzureInfrastructure:rssfeedurl: https://insearch.site/rssdd.xml
   LostFilmMonitoring.AzureInfrastructure:basefeedcookie:
     secure: v1:9i2Uloz+r/W0CA57:P+U9EUo1HSCVs2qbIrK2ikXEu3/5mZN1rVL3gGDZ38L6JcJbVvNT8yZtj9mmB45o
   LostFilmMonitoring.AzureInfrastructure:baselinkuid:

--- a/LostFilmMonitoring.AzureInfrastructure/Pulumi.prod.yaml
+++ b/LostFilmMonitoring.AzureInfrastructure/Pulumi.prod.yaml
@@ -1,6 +1,7 @@
 config:
   LostFilmMonitoring.AzureInfrastructure:location: westeurope
   LostFilmMonitoring.AzureInfrastructure:baseurl: https://datalostfilmfeed.byalex.dev
+  LostFilmMonitoring.AzureInfrastructure:rssfeedurl: https://insearch.site/rssdd.xml
   LostFilmMonitoring.AzureInfrastructure:torrenttrackers: http://bt.tracktor.in/tracker.php/{0}/announce,http://bt99.tracktor.in/tracker.php/{0}/announce,http://bt0.tracktor.in/tracker.php/{0}/announce,http://user5.newtrack.info/tracker.php/{0}/announce,http://user1.newtrack.info/tracker.php/{0}/announce
   LostFilmMonitoring.AzureInfrastructure:imagesdirectory: images
   LostFilmMonitoring.AzureInfrastructure:torrentsdirectory: torrentfiles

--- a/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/ConfigurationTests.cs
@@ -20,12 +20,15 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTTRACKERS")).Returns("#1{0},#2{0},#3{0}");
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
+        providerMock!.Setup(x => x.GetValue("RSS_FEED_URL")).Returns("RSS_FEED_URL");
         var service = GetService();
         using (Assert.EnterMultipleScope())
         {
             Assert.That(service.BaseUID, Is.EqualTo("BASELINKUID"));
             Assert.That(service.BaseUSESS, Is.EqualTo("BASEFEEDCOOKIE"));
             Assert.That(service.BaseUrl, Is.EqualTo("BASEURL"));
+            Assert.That(service.RssFeedUrl, Is.EqualTo("RSS_FEED_URL"));
+            Assert.That(service.RssFeedUrl, Is.EqualTo("RSS_FEED_URL"));
             Assert.That(service.GetTorrentAnnounceList("USERID"), Is.EqualTo(["#1USERID", "#2USERID", "#3USERID"]));
         }
     }
@@ -39,6 +42,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTTRACKERS")).Returns("#1{0},#2{0},#3{0}");
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
+        providerMock!.Setup(x => x.GetValue("RSS_FEED_URL")).Returns("RSS_FEED_URL");
         var service = GetService();
         Assert.That(service.GetTorrentAnnounceList(null!), Is.EqualTo(["#1BASELINKUID", "#2BASELINKUID", "#3BASELINKUID"]));
     }
@@ -94,6 +98,7 @@ public class ConfigurationTests
         providerMock!.Setup(x => x.GetValue("TORRENTTRACKERS")).Returns(null as string);
         providerMock!.Setup(x => x.GetValue("IMAGESDIRECTORY")).Returns("IMAGESDIRECTORY");
         providerMock!.Setup(x => x.GetValue("TORRENTSDIRECTORY")).Returns("TORRENTSDIRECTORY");
+        providerMock!.Setup(x => x.GetValue("RSS_FEED_URL")).Returns("RSS_FEED_URL");
 
         var action = () => GetService();
         Assert.That(Assert.Catch<Exception>(() => action())!.Message, Is.EqualTo("Environment variable 'TORRENTTRACKERS' is not defined."));

--- a/LostFilmMonitoring.BLL.Tests/LoggerTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/LoggerTests.cs
@@ -12,6 +12,7 @@ public class LoggerTests
         loggerMock = new();
         loggerFactoryMock = new();
         loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(loggerMock.Object);
+        loggerMock.Setup(x => x.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
     }
 
     [Test]

--- a/LostFilmMonitoring.BLL/Commands/SaveSubscriptionCommand.cs
+++ b/LostFilmMonitoring.BLL/Commands/SaveSubscriptionCommand.cs
@@ -117,22 +117,13 @@ public class SaveSubscriptionCommand : ICommand<EditSubscriptionRequestModel, Ed
     private async Task<IDictionary<Guid, string>> LoadSeriesIdToNameAsync()
     {
         var allSeries = await this.dal.Series.LoadAsync();
-        var result = new Dictionary<Guid, string>();
         if (allSeries == null)
         {
             this.logger.Error("No series found. Cannot load series ID to name dictionary.");
-            return result;
+            return new Dictionary<Guid, string>();
         }
 
-        foreach (var series in allSeries)
-        {
-            if (!result.TryAdd(series.Id, series.Name))
-            {
-                this.logger.Error($"Series ID '{series.Id}' already exists in the dictionary. Cannot load series ID to name dictionary.");
-            }
-        }
-
-        return result;
+        return allSeries.ToDictionary(x => x.Id, x => x.Name);
     }
 
     private Task UpdatePresentationModelAsync(string userId, SubscriptionItem[] selectedSubscriptions)

--- a/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs
+++ b/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs
@@ -24,14 +24,14 @@ public class UpdateFeedsCommand : ICommand
     public UpdateFeedsCommand(UpdateFeedsCommandDependencies dependencies)
     {
         ArgumentNullException.ThrowIfNull(dependencies);
-        this.logger = dependencies.Logger != null ? dependencies.Logger.CreateScope(nameof(UpdateFeedsCommand)) : throw new ArgumentNullException(nameof(dependencies.Logger));
-        this.dal = dependencies.Dal ?? throw new ArgumentNullException(nameof(dependencies.Dal));
-        this.configuration = dependencies.Configuration ?? throw new ArgumentNullException(nameof(dependencies.Configuration));
-        this.rssFeed = dependencies.RssFeed ?? throw new ArgumentNullException(nameof(dependencies.RssFeed));
-        this.modelPersister = dependencies.ModelPersister ?? throw new ArgumentNullException(nameof(dependencies.ModelPersister));
-        this.client = dependencies.Client ?? throw new ArgumentNullException(nameof(dependencies.Client));
-        this.torrentFileHelper = dependencies.TorrentFileHelper ?? throw new ArgumentNullException(nameof(dependencies.TorrentFileHelper));
-        this.downloadCoverImagesCommand = dependencies.DownloadCoverImagesCommand ?? throw new ArgumentNullException(nameof(dependencies.DownloadCoverImagesCommand));
+        this.logger = dependencies.Logger != null ? dependencies.Logger.CreateScope(nameof(UpdateFeedsCommand)) : throw new ArgumentNullException(nameof(dependencies));
+        this.dal = dependencies.Dal ?? throw new ArgumentNullException(nameof(dependencies));
+        this.configuration = dependencies.Configuration ?? throw new ArgumentNullException(nameof(dependencies));
+        this.rssFeed = dependencies.RssFeed ?? throw new ArgumentNullException(nameof(dependencies));
+        this.modelPersister = dependencies.ModelPersister ?? throw new ArgumentNullException(nameof(dependencies));
+        this.client = dependencies.Client ?? throw new ArgumentNullException(nameof(dependencies));
+        this.torrentFileHelper = dependencies.TorrentFileHelper ?? throw new ArgumentNullException(nameof(dependencies));
+        this.downloadCoverImagesCommand = dependencies.DownloadCoverImagesCommand ?? throw new ArgumentNullException(nameof(dependencies));
         this.updateUserFeedCommand = new UpdateUserFeedCommand(dependencies.Logger, dependencies.Dal, dependencies.Configuration);
     }
 

--- a/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs
+++ b/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs
@@ -24,13 +24,13 @@ public class UpdateFeedsCommand : ICommand
     public UpdateFeedsCommand(UpdateFeedsCommandDependencies dependencies)
     {
         ArgumentNullException.ThrowIfNull(dependencies);
-        this.logger = dependencies.Logger != null ? dependencies.Logger.CreateScope(nameof(UpdateFeedsCommand)) : throw new ArgumentNullException(nameof(dependencies));
-        this.dal = dependencies.Dal ?? throw new ArgumentNullException(nameof(dependencies));
-        this.configuration = dependencies.Configuration ?? throw new ArgumentNullException(nameof(dependencies));
-        this.rssFeed = dependencies.RssFeed ?? throw new ArgumentNullException(nameof(dependencies));
-        this.modelPersister = dependencies.ModelPersister ?? throw new ArgumentNullException(nameof(dependencies));
-        this.client = dependencies.Client ?? throw new ArgumentNullException(nameof(dependencies));
-        this.torrentFileHelper = dependencies.TorrentFileHelper ?? throw new ArgumentNullException(nameof(dependencies));
+        this.logger = dependencies.Logger != null ? dependencies.Logger.CreateScope(nameof(UpdateFeedsCommand)) : throw new ArgumentNullException(nameof(dependencies.Logger));
+        this.dal = dependencies.Dal ?? throw new ArgumentNullException(nameof(dependencies.Dal));
+        this.configuration = dependencies.Configuration ?? throw new ArgumentNullException(nameof(dependencies.Configuration));
+        this.rssFeed = dependencies.RssFeed ?? throw new ArgumentNullException(nameof(dependencies.RssFeed));
+        this.modelPersister = dependencies.ModelPersister ?? throw new ArgumentNullException(nameof(dependencies.ModelPersister));
+        this.client = dependencies.Client ?? throw new ArgumentNullException(nameof(dependencies.Client));
+        this.torrentFileHelper = dependencies.TorrentFileHelper ?? throw new ArgumentNullException(nameof(dependencies.TorrentFileHelper));
         this.downloadCoverImagesCommand = dependencies.DownloadCoverImagesCommand ?? throw new ArgumentNullException(nameof(dependencies));
         this.updateUserFeedCommand = new UpdateUserFeedCommand(dependencies.Logger, dependencies.Dal, dependencies.Configuration);
     }

--- a/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs
+++ b/LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs
@@ -8,40 +8,40 @@ public class UpdateFeedsCommandDependencies
     /// <summary>
     /// Gets or sets the logger instance.
     /// </summary>
-    public required ILogger Logger { get; set; }
+    required public ILogger Logger { get; set; }
 
     /// <summary>
     /// Gets or sets the RSS feed loader.
     /// </summary>
-    public required IRssFeed RssFeed { get; set; }
+    required public IRssFeed RssFeed { get; set; }
 
     /// <summary>
     /// Gets or sets the data access layer.
     /// </summary>
-    public required IDal Dal { get; set; }
+    required public IDal Dal { get; set; }
 
     /// <summary>
     /// Gets or sets the configuration provider.
     /// </summary>
-    public required IConfiguration Configuration { get; set; }
+    required public IConfiguration Configuration { get; set; }
 
     /// <summary>
     /// Gets or sets the model persister.
     /// </summary>
-    public required IModelPersister ModelPersister { get; set; }
+    required public IModelPersister ModelPersister { get; set; }
 
     /// <summary>
     /// Gets or sets the LostFilm client.
     /// </summary>
-    public required ILostFilmClient Client { get; set; }
+    required public ILostFilmClient Client { get; set; }
 
     /// <summary>
     /// Gets or sets the torrent file helper.
     /// </summary>
-    public required ITorrentFileHelper TorrentFileHelper { get; set; }
+    required public ITorrentFileHelper TorrentFileHelper { get; set; }
 
     /// <summary>
     /// Gets or sets the command for downloading cover images.
     /// </summary>
-    public required ICommand<Series> DownloadCoverImagesCommand { get; set; }
+    required public ICommand<Series> DownloadCoverImagesCommand { get; set; }
 }

--- a/LostFilmMonitoring.BLL/Configuration.cs
+++ b/LostFilmMonitoring.BLL/Configuration.cs
@@ -15,6 +15,7 @@ public class Configuration : IConfiguration
         this.BaseUrl = provider.GetValue(EnvironmentVariables.BaseUrl) ?? throw new InvalidOperationException($"Environment variable '{EnvironmentVariables.BaseUrl}' is not defined.");
         this.BaseUSESS = provider.GetValue(EnvironmentVariables.BaseFeedCookie) ?? throw new InvalidOperationException($"Environment variable '{EnvironmentVariables.BaseFeedCookie}' is not defined.");
         this.BaseUID = provider.GetValue(EnvironmentVariables.BaseLinkUID) ?? throw new InvalidOperationException($"Environment variable '{EnvironmentVariables.BaseLinkUID}' is not defined.");
+        this.RssFeedUrl = provider.GetValue(EnvironmentVariables.RssFeedUrl) ?? throw new InvalidOperationException($"Environment variable '{EnvironmentVariables.RssFeedUrl}' is not defined.");
         this.torrentAnnounceListPatterns = provider.GetValue(EnvironmentVariables.TorrentTrackers)?.Split(',', StringSplitOptions.RemoveEmptyEntries) ?? throw new InvalidOperationException($"Environment variable '{EnvironmentVariables.TorrentTrackers}' is not defined.");
     }
 
@@ -26,6 +27,9 @@ public class Configuration : IConfiguration
 
     /// <inheritdoc/>
     public string BaseUID { get; private set; }
+
+    /// <inheritdoc/>
+    public string RssFeedUrl { get; private set; }
 
     /// <inheritdoc/>
     public string[] GetTorrentAnnounceList(string link_uid)

--- a/LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs
+++ b/LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs
@@ -1,11 +1,8 @@
 ﻿namespace LostFilmMonitoring.BLL.Exceptions;
 
-using System.Runtime.Serialization;
-
 /// <summary>
 /// Generic exception that covers all communication issues to external services.
 /// </summary>
-[Serializable]
 public sealed class ExternalServiceUnavailableException : Exception
 {
     /// <summary>
@@ -31,16 +28,6 @@ public sealed class ExternalServiceUnavailableException : Exception
     /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
     /// </summary>
     private ExternalServiceUnavailableException()
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
-    /// </summary>
-    /// <param name="info">The SerializationInfo object.</param>
-    /// <param name="context">The StreamingContext object.</param>
-    private ExternalServiceUnavailableException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs
+++ b/LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs
@@ -1,10 +1,12 @@
 ﻿namespace LostFilmMonitoring.BLL.Exceptions;
 
+using System.Runtime.Serialization;
+
 /// <summary>
 /// Generic exception that covers all communication issues to external services.
 /// </summary>
 [Serializable]
-public sealed class ExternalServiceUnavailableException : Exception, ISerializable
+public sealed class ExternalServiceUnavailableException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
@@ -16,7 +18,29 @@ public sealed class ExternalServiceUnavailableException : Exception, ISerializab
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="message">Message that describes what happened.</param>
+    public ExternalServiceUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
+    /// </summary>
     private ExternalServiceUnavailableException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExternalServiceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="info">The SerializationInfo object.</param>
+    /// <param name="context">The StreamingContext object.</param>
+    private ExternalServiceUnavailableException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
     }
 }

--- a/LostFilmMonitoring.BLL/FeedItemResponse.cs
+++ b/LostFilmMonitoring.BLL/FeedItemResponse.cs
@@ -90,4 +90,118 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
 
         return string.Compare(this.Title, that.Title, StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        if (obj is not FeedItemResponse other)
+        {
+            return false;
+        }
+
+        return this.PublishDateParsed == other.PublishDateParsed
+            && string.Equals(this.Title, other.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.PublishDateParsed, this.Title?.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Determines whether two specified instances are equal.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is equal to right; otherwise, false.</returns>
+    public static bool operator ==(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        if (ReferenceEquals(left, right))
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.Equals(right);
+    }
+
+    /// <summary>
+    /// Determines whether two specified instances are not equal.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is not equal to right; otherwise, false.</returns>
+    public static bool operator !=(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        return !(left == right);
+    }
+
+    /// <summary>
+    /// Determines whether one specified instance is less than another specified instance.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is less than right; otherwise, false.</returns>
+    public static bool operator <(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.CompareTo(right) < 0;
+    }
+
+    /// <summary>
+    /// Determines whether one specified instance is less than or equal to another specified instance.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is less than or equal to right; otherwise, false.</returns>
+    public static bool operator <=(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.CompareTo(right) <= 0;
+    }
+
+    /// <summary>
+    /// Determines whether one specified instance is greater than another specified instance.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is greater than right; otherwise, false.</returns>
+    public static bool operator >(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.CompareTo(right) > 0;
+    }
+
+    /// <summary>
+    /// Determines whether one specified instance is greater than or equal to another specified instance.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>true if left is greater than or equal to right; otherwise, false.</returns>
+    public static bool operator >=(FeedItemResponse? left, FeedItemResponse? right)
+    {
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.CompareTo(right) >= 0;
+    }
 }

--- a/LostFilmMonitoring.BLL/FeedItemResponse.cs
+++ b/LostFilmMonitoring.BLL/FeedItemResponse.cs
@@ -70,45 +70,6 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
     /// </summary>
     public string? TorrentId { get; set; }
 
-    /// <inheritdoc/>
-    int IComparable<FeedItemResponse>.CompareTo(FeedItemResponse? that)
-    {
-        if (that == null)
-        {
-            return 1;
-        }
-
-        if (this.PublishDateParsed < that.PublishDateParsed)
-        {
-            return 1;
-        }
-
-        if (this.PublishDateParsed > that.PublishDateParsed)
-        {
-            return -1;
-        }
-
-        return string.Compare(this.Title, that.Title, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <inheritdoc/>
-    public override bool Equals(object? obj)
-    {
-        if (obj is not FeedItemResponse other)
-        {
-            return false;
-        }
-
-        return this.PublishDateParsed == other.PublishDateParsed
-            && string.Equals(this.Title, other.Title, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <inheritdoc/>
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(this.PublishDateParsed, this.Title?.ToLowerInvariant());
-    }
-
     /// <summary>
     /// Determines whether two specified instances are equal.
     /// </summary>
@@ -154,7 +115,7 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
             return false;
         }
 
-        return left.CompareTo(right) < 0;
+        return ((IComparable<FeedItemResponse>)left).CompareTo(right) < 0;
     }
 
     /// <summary>
@@ -170,7 +131,7 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
             return false;
         }
 
-        return left.CompareTo(right) <= 0;
+        return ((IComparable<FeedItemResponse>)left).CompareTo(right) <= 0;
     }
 
     /// <summary>
@@ -186,7 +147,7 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
             return false;
         }
 
-        return left.CompareTo(right) > 0;
+        return ((IComparable<FeedItemResponse>)left).CompareTo(right) > 0;
     }
 
     /// <summary>
@@ -202,6 +163,45 @@ public class FeedItemResponse : IComparable<FeedItemResponse>
             return false;
         }
 
-        return left.CompareTo(right) >= 0;
+        return ((IComparable<FeedItemResponse>)left).CompareTo(right) >= 0;
+    }
+
+    /// <inheritdoc/>
+    int IComparable<FeedItemResponse>.CompareTo(FeedItemResponse? that)
+    {
+        if (that == null)
+        {
+            return 1;
+        }
+
+        if (this.PublishDateParsed < that.PublishDateParsed)
+        {
+            return 1;
+        }
+
+        if (this.PublishDateParsed > that.PublishDateParsed)
+        {
+            return -1;
+        }
+
+        return string.Compare(this.Title, that.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj)
+    {
+        if (obj is not FeedItemResponse other)
+        {
+            return false;
+        }
+
+        return this.PublishDateParsed == other.PublishDateParsed
+            && string.Equals(this.Title, other.Title, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(this.PublishDateParsed, this.Title?.ToLowerInvariant());
     }
 }

--- a/LostFilmMonitoring.BLL/Logger.cs
+++ b/LostFilmMonitoring.BLL/Logger.cs
@@ -32,25 +32,67 @@ public class Logger : Common.ILogger
     }
 
     /// <inheritdoc/>
-    public void Debug(string message) => this.logger.LogDebug(this.WrapMessage(message));
+    public void Debug(string message)
+    {
+        if (this.logger.IsEnabled(LogLevel.Debug))
+        {
+            this.logger.LogDebug(this.WrapMessage(message));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Error(string message) => this.logger.LogError(this.WrapMessage(message));
+    public void Error(string message)
+    {
+        if (this.logger.IsEnabled(LogLevel.Error))
+        {
+            this.logger.LogError(this.WrapMessage(message));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Fatal(string message) => this.logger.LogCritical(this.WrapMessage(message));
+    public void Fatal(string message)
+    {
+        if (this.logger.IsEnabled(LogLevel.Critical))
+        {
+            this.logger.LogCritical(this.WrapMessage(message));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Info(string message) => this.logger.LogInformation(this.WrapMessage(message));
+    public void Info(string message)
+    {
+        if (this.logger.IsEnabled(LogLevel.Information))
+        {
+            this.logger.LogInformation(this.WrapMessage(message));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Log(Exception ex) => this.logger.LogCritical(ex, this.WrapMessage("Exception occurred."));
+    public void Log(Exception ex)
+    {
+        if (this.logger.IsEnabled(LogLevel.Critical))
+        {
+            this.logger.LogCritical(ex, this.WrapMessage("Exception occurred."));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Log(string message, Exception ex) => this.logger.LogCritical(ex, this.WrapMessage(message));
+    public void Log(string message, Exception ex)
+    {
+        if (this.logger.IsEnabled(LogLevel.Critical))
+        {
+            this.logger.LogCritical(ex, this.WrapMessage(message));
+        }
+    }
 
     /// <inheritdoc/>
-    public void Warning(string message) => this.logger.LogWarning(this.WrapMessage(message));
+    public void Warning(string message)
+    {
+        if (this.logger.IsEnabled(LogLevel.Warning))
+        {
+            this.logger.LogWarning(this.WrapMessage(message));
+        }
+    }
 
     private void SetScope(string name)
     {

--- a/LostFilmMonitoring.BLL/LostFilmMonitoring.BLL.xml
+++ b/LostFilmMonitoring.BLL/LostFilmMonitoring.BLL.xml
@@ -237,6 +237,9 @@
         <member name="P:LostFilmMonitoring.BLL.Configuration.BaseUID">
             <inheritdoc/>
         </member>
+        <member name="P:LostFilmMonitoring.BLL.Configuration.RssFeedUrl">
+            <inheritdoc/>
+        </member>
         <member name="M:LostFilmMonitoring.BLL.Configuration.GetTorrentAnnounceList(System.String)">
             <inheritdoc/>
         </member>
@@ -259,6 +262,17 @@
             </summary>
             <param name="message">Message that describes what happened.</param>
             <param name="innerException">Actual exception occurred.</param>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.Exceptions.ExternalServiceUnavailableException.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:LostFilmMonitoring.BLL.Exceptions.ExternalServiceUnavailableException"/> class.
+            </summary>
+            <param name="message">Message that describes what happened.</param>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.Exceptions.ExternalServiceUnavailableException.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:LostFilmMonitoring.BLL.Exceptions.ExternalServiceUnavailableException"/> class.
+            </summary>
         </member>
         <member name="T:LostFilmMonitoring.BLL.Extensions">
             <summary>
@@ -379,7 +393,61 @@
             Gets or sets TorrentId.
             </summary>
         </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_Equality(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether two specified instances are equal.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is equal to right; otherwise, false.</returns>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_Inequality(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether two specified instances are not equal.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is not equal to right; otherwise, false.</returns>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_LessThan(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether one specified instance is less than another specified instance.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is less than right; otherwise, false.</returns>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_LessThanOrEqual(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether one specified instance is less than or equal to another specified instance.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is less than or equal to right; otherwise, false.</returns>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_GreaterThan(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether one specified instance is greater than another specified instance.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is greater than right; otherwise, false.</returns>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.op_GreaterThanOrEqual(LostFilmMonitoring.BLL.FeedItemResponse,LostFilmMonitoring.BLL.FeedItemResponse)">
+            <summary>
+            Determines whether one specified instance is greater than or equal to another specified instance.
+            </summary>
+            <param name="left">The left operand.</param>
+            <param name="right">The right operand.</param>
+            <returns>true if left is greater than or equal to right; otherwise, false.</returns>
+        </member>
         <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.System#IComparable{LostFilmMonitoring#BLL#FeedItemResponse}#CompareTo(LostFilmMonitoring.BLL.FeedItemResponse)">
+            <inheritdoc/>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.Equals(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="M:LostFilmMonitoring.BLL.FeedItemResponse.GetHashCode">
             <inheritdoc/>
         </member>
         <member name="T:LostFilmMonitoring.BLL.FeedItemResponseEqualityComparer">

--- a/LostFilmMonitoring.BLL/Validators/EditSubscriptionRequestModelValidator.cs
+++ b/LostFilmMonitoring.BLL/Validators/EditSubscriptionRequestModelValidator.cs
@@ -43,7 +43,7 @@ public class EditSubscriptionRequestModelValidator : IValidator<EditSubscription
 
             if (!IsIn(item.Quality, Quality.SD, Quality.H1080, Quality.H720))
             {
-                result.SetError(nameof(item.Quality), string.Format(ErrorMessages.ShouldBeIn, nameof(item.Quality), string.Join(", ", [Quality.SD, Quality.H1080, Quality.H720])));
+                result.SetError(nameof(item.Quality), string.Format(ErrorMessages.ShouldBeIn, nameof(item.Quality), string.Join(", ", Quality.SD, Quality.H1080, Quality.H720)));
                 return result;
             }
 

--- a/LostFilmMonitoring.Common/EnvironmentVariables.cs
+++ b/LostFilmMonitoring.Common/EnvironmentVariables.cs
@@ -39,4 +39,9 @@ public static class EnvironmentVariables
     /// List of torrent trackers.
     /// </summary>
     public static readonly string TorrentTrackers = "TORRENTTRACKERS";
+
+    /// <summary>
+    /// RSS Feed URL.
+    /// </summary>
+    public static readonly string RssFeedUrl = "RSS_FEED_URL";
 }

--- a/LostFilmMonitoring.Common/IConfiguration.cs
+++ b/LostFilmMonitoring.Common/IConfiguration.cs
@@ -24,6 +24,12 @@ public interface IConfiguration
     string BaseUrl { get; }
 
     /// <summary>
+    /// Gets the RSS feed URL.
+    /// </summary>
+    /// <returns>The RSS feed URL.</returns>
+    string RssFeedUrl { get; }
+
+    /// <summary>
     /// Get list of torrent trackers for torrent file.
     /// </summary>
     /// <param name="link_uid">Torrent tracker user identifier.</param>

--- a/LostFilmMonitoring.Common/LostFilmMonitoring.Common.xml
+++ b/LostFilmMonitoring.Common/LostFilmMonitoring.Common.xml
@@ -182,6 +182,11 @@
             List of torrent trackers.
             </summary>
         </member>
+        <member name="F:LostFilmMonitoring.Common.EnvironmentVariables.RssFeedUrl">
+            <summary>
+            RSS Feed URL.
+            </summary>
+        </member>
         <member name="T:LostFilmMonitoring.Common.IConfiguration">
             <summary>
             Configuration.
@@ -204,6 +209,12 @@
             Gets base url where website is hosted.
             </summary>
             <returns>Base url where website is hosted.</returns>
+        </member>
+        <member name="P:LostFilmMonitoring.Common.IConfiguration.RssFeedUrl">
+            <summary>
+            Gets the RSS feed URL.
+            </summary>
+            <returns>The RSS feed URL.</returns>
         </member>
         <member name="M:LostFilmMonitoring.Common.IConfiguration.GetTorrentAnnounceList(System.String)">
             <summary>

--- a/LostFilmMonitoring.DAO.Azure.Tests/TestAsyncEnumerator.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/TestAsyncEnumerator.cs
@@ -3,19 +3,21 @@
 [ExcludeFromCodeCoverage]
 public class TestAsyncEnumerator<T> : IAsyncEnumerator<T>
 {
-    private readonly IEnumerable<T> values;
+    private readonly T[] values;
     private readonly IEnumerator<T> enumerator;
     
     public TestAsyncEnumerator(T[] values)
     {
         this.values = values;
-        this.enumerator = this.values.GetEnumerator();
+        this.enumerator = ((IEnumerable<T>)this.values).GetEnumerator();
     }
     
     public T Current => enumerator.Current;
 
     public ValueTask DisposeAsync()
     {
+        this.enumerator?.Dispose();
+        GC.SuppressFinalize(this);
         return new ValueTask();
     }
 

--- a/LostFilmMonitoring.DAO.Azure.Tests/TestResponseOk.cs
+++ b/LostFilmMonitoring.DAO.Azure.Tests/TestResponseOk.cs
@@ -12,7 +12,7 @@ public class TestResponseOk : Response
 
     public override void Dispose()
     {
-        // No unmanaged resources to dispose in this test stub.
+        GC.SuppressFinalize(this);
     }
 
     protected override bool ContainsHeader(string name)

--- a/LostFilmTV.Client.Tests/FeedItemResponseTests.cs
+++ b/LostFilmTV.Client.Tests/FeedItemResponseTests.cs
@@ -335,12 +335,12 @@ public class FeedItemResponseTests
         watch.Stop();
 
         // Should complete quickly (well under the 100ms timeout)
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(watch.ElapsedMilliseconds, Is.LessThan(50), "Regex should complete quickly on malformed input");
             Assert.That(ok, Is.False);
             Assert.That(feedItemResponse, Is.Null, "Malformed input should result in null feedItemResponse");
-        });
+        }
     }
 
     [Test]

--- a/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
+++ b/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
@@ -7,7 +7,7 @@ public class ReteOrgRssFeedTests
 {
     private Mock<IHttpClientFactory> httpClientFactory;
     private Mock<ILogger> logger;
-    private Mock<Common.IConfiguration> configuration;
+    private Mock<IConfiguration> configuration;
     private MockHttpMessageHandler mockHttp;
 
     [SetUp]

--- a/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
+++ b/LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs
@@ -7,6 +7,7 @@ public class ReteOrgRssFeedTests
 {
     private Mock<IHttpClientFactory> httpClientFactory;
     private Mock<ILogger> logger;
+    private Mock<Common.IConfiguration> configuration;
     private MockHttpMessageHandler mockHttp;
 
     [SetUp]
@@ -15,6 +16,8 @@ public class ReteOrgRssFeedTests
         this.httpClientFactory = new();
         this.logger = new();
         this.logger.Setup(l => l.CreateScope(It.IsAny<string>())).Returns(this.logger.Object);
+        this.configuration = new();
+        this.configuration.Setup(c => c.RssFeedUrl).Returns("https://insearch.site/rssdd.xml");
         this.mockHttp = new();
         this.httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(new HttpClient(mockHttp));
     }
@@ -22,22 +25,29 @@ public class ReteOrgRssFeedTests
     [Test]
     public void Constructor_should_throw_exception_when_logger_null()
     {
-        var action = () => new ReteOrgRssFeed(null!, this.httpClientFactory.Object);
+        var action = () => new ReteOrgRssFeed(null!, this.httpClientFactory.Object, this.configuration.Object);
         Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_logger_createScope_null()
     {
-        var action = () => new ReteOrgRssFeed(new Mock<ILogger>().Object, this.httpClientFactory.Object);
+        var action = () => new ReteOrgRssFeed(new Mock<ILogger>().Object, this.httpClientFactory.Object, this.configuration.Object);
         Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("logger"));
     }
 
     [Test]
     public void Constructor_should_throw_exception_when_httpClientFactory_null()
     {
-        var action = () => new ReteOrgRssFeed(this.logger.Object, null!);
+        var action = () => new ReteOrgRssFeed(this.logger.Object, null!, this.configuration.Object);
         Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("httpClientFactory"));
+    }
+
+    [Test]
+    public void Constructor_should_throw_exception_when_configuration_null()
+    {
+        var action = () => new ReteOrgRssFeed(this.logger.Object, this.httpClientFactory.Object, null!);
+        Assert.That(Assert.Throws<ArgumentNullException>(() => action()), Has.Property(nameof(ArgumentNullException.ParamName)).EqualTo("configuration"));
     }
 
     [Test]
@@ -133,5 +143,5 @@ public class ReteOrgRssFeedTests
         Assert.That(result!.First().Link, Is.EqualTo("http://n.tracktor.site/rssdownloader.php?id=51236&source=test"));
     }
 
-    private ReteOrgRssFeed GetService() => new(this.logger.Object, this.httpClientFactory.Object);
+    private ReteOrgRssFeed GetService() => new(this.logger.Object, this.httpClientFactory.Object, this.configuration.Object);
 }

--- a/LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs
+++ b/LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs
@@ -7,7 +7,7 @@ using System.Runtime.Serialization;
 /// RemoteServiceUnavailableException.
 /// </summary>
 [Serializable]
-public class RemoteServiceUnavailableException : Exception, ISerializable
+public class RemoteServiceUnavailableException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RemoteServiceUnavailableException"/> class.
@@ -15,6 +15,35 @@ public class RemoteServiceUnavailableException : Exception, ISerializable
     /// <param name="innerException">Instance of <see cref="Exception"/>.</param>
     public RemoteServiceUnavailableException(Exception innerException)
         : base("Remote Service Unavailable", innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteServiceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="message">Message that describes what happened.</param>
+    public RemoteServiceUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteServiceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="message">Message that describes what happened.</param>
+    /// <param name="innerException">Actual exception occurred.</param>
+    public RemoteServiceUnavailableException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoteServiceUnavailableException"/> class.
+    /// </summary>
+    /// <param name="info">The SerializationInfo object.</param>
+    /// <param name="context">The StreamingContext object.</param>
+    protected RemoteServiceUnavailableException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
     {
     }
 }

--- a/LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs
+++ b/LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs
@@ -1,12 +1,10 @@
 ﻿namespace LostFilmTV.Client.Exceptions;
 
 using System;
-using System.Runtime.Serialization;
 
 /// <summary>
 /// RemoteServiceUnavailableException.
 /// </summary>
-[Serializable]
 public class RemoteServiceUnavailableException : Exception
 {
     /// <summary>
@@ -34,16 +32,6 @@ public class RemoteServiceUnavailableException : Exception
     /// <param name="innerException">Actual exception occurred.</param>
     public RemoteServiceUnavailableException(string message, Exception innerException)
         : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RemoteServiceUnavailableException"/> class.
-    /// </summary>
-    /// <param name="info">The SerializationInfo object.</param>
-    /// <param name="context">The StreamingContext object.</param>
-    protected RemoteServiceUnavailableException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 }

--- a/LostFilmTV.Client/LostFilmTV.Client.xml
+++ b/LostFilmTV.Client/LostFilmTV.Client.xml
@@ -15,6 +15,19 @@
             </summary>
             <param name="innerException">Instance of <see cref="T:System.Exception"/>.</param>
         </member>
+        <member name="M:LostFilmTV.Client.Exceptions.RemoteServiceUnavailableException.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:LostFilmTV.Client.Exceptions.RemoteServiceUnavailableException"/> class.
+            </summary>
+            <param name="message">Message that describes what happened.</param>
+        </member>
+        <member name="M:LostFilmTV.Client.Exceptions.RemoteServiceUnavailableException.#ctor(System.String,System.Exception)">
+            <summary>
+            Initializes a new instance of the <see cref="T:LostFilmTV.Client.Exceptions.RemoteServiceUnavailableException"/> class.
+            </summary>
+            <param name="message">Message that describes what happened.</param>
+            <param name="innerException">Actual exception occurred.</param>
+        </member>
         <member name="T:LostFilmTV.Client.LostFilmClient">
             <summary>
             Client for LostFilm.TV
@@ -166,12 +179,13 @@
             ReteOrgRssFeedService.
             </summary>
         </member>
-        <member name="M:LostFilmTV.Client.RssFeed.ReteOrgRssFeed.#ctor(LostFilmMonitoring.Common.ILogger,System.Net.Http.IHttpClientFactory)">
+        <member name="M:LostFilmTV.Client.RssFeed.ReteOrgRssFeed.#ctor(LostFilmMonitoring.Common.ILogger,System.Net.Http.IHttpClientFactory,LostFilmMonitoring.Common.IConfiguration)">
             <summary>
             Initializes a new instance of the <see cref="T:LostFilmTV.Client.RssFeed.ReteOrgRssFeed"/> class.
             </summary>
             <param name="logger">Logger.</param>
             <param name="httpClientFactory">httpClientFactory.</param>
+            <param name="configuration">Configuration provider.</param>
         </member>
         <member name="M:LostFilmTV.Client.RssFeed.ReteOrgRssFeed.LoadFeedItemsAsync">
             <summary>

--- a/LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs
+++ b/LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs
@@ -13,7 +13,7 @@ public class ReteOrgRssFeed : BaseRssFeed, IRssFeed
     /// <param name="logger">Logger.</param>
     /// <param name="httpClientFactory">httpClientFactory.</param>
     /// <param name="configuration">Configuration provider.</param>
-    public ReteOrgRssFeed(ILogger logger, IHttpClientFactory httpClientFactory, Common.IConfiguration configuration)
+    public ReteOrgRssFeed(ILogger logger, IHttpClientFactory httpClientFactory, IConfiguration configuration)
         : base(logger?.CreateScope(nameof(ReteOrgRssFeed)) ?? throw new ArgumentNullException(nameof(logger)), httpClientFactory)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs
+++ b/LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs
@@ -5,16 +5,19 @@
 /// </summary>
 public class ReteOrgRssFeed : BaseRssFeed, IRssFeed
 {
-    private const string RssUrl = "https://insearch.site/rssdd.xml";
+    private readonly string rssUrl;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ReteOrgRssFeed"/> class.
     /// </summary>
     /// <param name="logger">Logger.</param>
     /// <param name="httpClientFactory">httpClientFactory.</param>
-    public ReteOrgRssFeed(ILogger logger, IHttpClientFactory httpClientFactory)
+    /// <param name="configuration">Configuration provider.</param>
+    public ReteOrgRssFeed(ILogger logger, IHttpClientFactory httpClientFactory, Common.IConfiguration configuration)
         : base(logger?.CreateScope(nameof(ReteOrgRssFeed)) ?? throw new ArgumentNullException(nameof(logger)), httpClientFactory)
     {
+        ArgumentNullException.ThrowIfNull(configuration);
+        this.rssUrl = configuration.RssFeedUrl;
     }
 
     /// <summary>
@@ -27,7 +30,7 @@ public class ReteOrgRssFeed : BaseRssFeed, IRssFeed
         string rss = string.Empty;
         try
         {
-            rss = await this.DownloadRssTextAsync(RssUrl);
+            rss = await this.DownloadRssTextAsync(this.rssUrl);
         }
         catch (RemoteServiceUnavailableException)
         {

--- a/TMDB.Client/TmdbClient.cs
+++ b/TMDB.Client/TmdbClient.cs
@@ -57,7 +57,7 @@ public class TmdbClient : ITmdbClient
             }
 
             // We need to get config before requesting image bytes, otherwise it won't work.
-            var config = await this.client.GetConfigAsync();
+            await this.client.GetConfigAsync();
             var imageBytes = await this.client.GetImageBytesAsync("w185", poster.FilePath);
             this.logger.Info($"Image downloaded: {originalName}");
             return new MemoryStream(imageBytes);


### PR DESCRIPTION
## Fix SonarQube issues for `lAnubisl_LostFilmTorrentsFeed`

| Field | Value |
| --- | --- |
| SonarQube project | `lAnubisl_LostFilmTorrentsFeed` |
| SonarQube branch | `master` |
| Base branch | `master` |
| Generated branch | `copilot/sonar-fixes/lAnubisl_LostFilmTorrentsFeed/20260629212810` |
| Issues selected | `60` |
| Issues attempted | `60` |

## Copilot Session Summary

```text
Changes    +281 -50
AI Credits 78.8 (4m 47s)
Tokens     ↑ 4.5m (4.4m cached, 155.7k written) • ↓ 31.6k (7.0k reasoning)
```

## Issue List
- [AZ8VQiPaaGlcg1M-FbfO](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfO&open=AZ8VQiPaaGlcg1M-FbfO) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `27`
- [AZ8VQiPaaGlcg1M-FbfW](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfW&open=AZ8VQiPaaGlcg1M-FbfW) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `27`
- [AZ8VQiPaaGlcg1M-FbfP](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfP&open=AZ8VQiPaaGlcg1M-FbfP) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `28`
- [AZ8VQiPaaGlcg1M-FbfX](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfX&open=AZ8VQiPaaGlcg1M-FbfX) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `28`
- [AZ8VQiPaaGlcg1M-FbfQ](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfQ&open=AZ8VQiPaaGlcg1M-FbfQ) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `29`
- [AZ8VQiPaaGlcg1M-FbfY](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfY&open=AZ8VQiPaaGlcg1M-FbfY) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `29`
- [AZ8VQiPaaGlcg1M-FbfR](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfR&open=AZ8VQiPaaGlcg1M-FbfR) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `30`
- [AZ8VQiPaaGlcg1M-FbfZ](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfZ&open=AZ8VQiPaaGlcg1M-FbfZ) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `30`
- [AZ8VQiPaaGlcg1M-FbfS](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfS&open=AZ8VQiPaaGlcg1M-FbfS) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `31`
- [AZ8VQiPaaGlcg1M-Fbfa](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-Fbfa&open=AZ8VQiPaaGlcg1M-Fbfa) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `31`
- [AZ8VQiPaaGlcg1M-FbfT](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfT&open=AZ8VQiPaaGlcg1M-FbfT) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `32`
- [AZ8VQiPaaGlcg1M-Fbfb](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-Fbfb&open=AZ8VQiPaaGlcg1M-Fbfb) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `32`
- [AZ8VQiPaaGlcg1M-FbfU](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfU&open=AZ8VQiPaaGlcg1M-FbfU) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `33`
- [AZ8VQiPaaGlcg1M-Fbfc](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-Fbfc&open=AZ8VQiPaaGlcg1M-Fbfc) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `33`
- [AZ8VQiPaaGlcg1M-FbfV](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-FbfV&open=AZ8VQiPaaGlcg1M-FbfV) `csharpsquid:S3928` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `34`
- [AZ8VQiPaaGlcg1M-Fbfd](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPaaGlcg1M-Fbfd&open=AZ8VQiPaaGlcg1M-Fbfd) `external_roslyn:CA2208` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs` line `34`
- [AZ8VQiPtaGlcg1M-Fbfe](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfe&open=AZ8VQiPtaGlcg1M-Fbfe) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `11`
- [AZ8VQiPtaGlcg1M-Fbff](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbff&open=AZ8VQiPtaGlcg1M-Fbff) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `16`
- [AZ8VQiPtaGlcg1M-Fbfg](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfg&open=AZ8VQiPtaGlcg1M-Fbfg) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `21`
- [AZ8VQiPtaGlcg1M-Fbfh](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfh&open=AZ8VQiPtaGlcg1M-Fbfh) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `26`
- [AZ8VQiPtaGlcg1M-Fbfi](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfi&open=AZ8VQiPtaGlcg1M-Fbfi) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `31`
- [AZ8VQiPtaGlcg1M-Fbfj](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfj&open=AZ8VQiPtaGlcg1M-Fbfj) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `36`
- [AZ8VQiPtaGlcg1M-Fbfk](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfk&open=AZ8VQiPtaGlcg1M-Fbfk) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `41`
- [AZ8VQiPtaGlcg1M-Fbfl](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiPtaGlcg1M-Fbfl&open=AZ8VQiPtaGlcg1M-Fbfl) `external_roslyn:SA1206` `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs` line `46`
- [AZ8VQiUuaGlcg1M-Fbfm](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ8VQiUuaGlcg1M-Fbfm&open=AZ8VQiUuaGlcg1M-Fbfm) `external_roslyn:NUnit2056` `LostFilmTV.Client.Tests/FeedItemResponseTests.cs` line `338`
- [AZ2Y3CQb8vXIT0bFPOka](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOka&open=AZ2Y3CQb8vXIT0bFPOka) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `33`
- [AZ2Y3CQb8vXIT0bFPOke](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOke&open=AZ2Y3CQb8vXIT0bFPOke) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `63`
- [AZ2Y3CQb8vXIT0bFPOki](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOki&open=AZ2Y3CQb8vXIT0bFPOki) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `79`
- [AZ2Y3CQb8vXIT0bFPOkm](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkm&open=AZ2Y3CQb8vXIT0bFPOkm) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `110`
- [AZ2Y3CQb8vXIT0bFPOkp](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkp&open=AZ2Y3CQb8vXIT0bFPOkp) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `127`
- [AZwdwDp8rlb-ZKk71zU1](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZwdwDp8rlb-ZKk71zU1&open=AZwdwDp8rlb-ZKk71zU1) `csharpsquid:S3267` `LostFilmMonitoring.BLL/Commands/SaveSubscriptionCommand.cs` line `127`
- [AZW2D1JIc1xxlVLzcy2_](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZW2D1JIc1xxlVLzcy2_&open=AZW2D1JIc1xxlVLzcy2_) `csharpsquid:S1210` `LostFilmMonitoring.BLL/FeedItemResponse.cs` line `6`
- [AZW2D1ONc1xxlVLzcy7J](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZW2D1ONc1xxlVLzcy7J&open=AZW2D1ONc1xxlVLzcy7J) `csharpsquid:S1481` `TMDB.Client/TmdbClient.cs` line `60`
- [AZ2Y3CQb8vXIT0bFPOkZ](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkZ&open=AZ2Y3CQb8vXIT0bFPOkZ) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `32`
- [AZ2Y3CQb8vXIT0bFPOkb](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkb&open=AZ2Y3CQb8vXIT0bFPOkb) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `34`
- [AZ2Y3CQb8vXIT0bFPOkc](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkc&open=AZ2Y3CQb8vXIT0bFPOkc) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `35`
- [AZ2Y3CQb8vXIT0bFPOkd](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkd&open=AZ2Y3CQb8vXIT0bFPOkd) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `62`
- [AZ2Y3CQb8vXIT0bFPOkf](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkf&open=AZ2Y3CQb8vXIT0bFPOkf) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `64`
- [AZ2Y3CQb8vXIT0bFPOkg](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkg&open=AZ2Y3CQb8vXIT0bFPOkg) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `65`
- [AZ2Y3CQb8vXIT0bFPOkh](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkh&open=AZ2Y3CQb8vXIT0bFPOkh) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `78`
- [AZ2Y3CQb8vXIT0bFPOkj](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkj&open=AZ2Y3CQb8vXIT0bFPOkj) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `80`
- [AZ2Y3CQb8vXIT0bFPOkk](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkk&open=AZ2Y3CQb8vXIT0bFPOkk) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `81`
- [AZ2Y3CQb8vXIT0bFPOkl](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkl&open=AZ2Y3CQb8vXIT0bFPOkl) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `109`
- [AZ2Y3CQb8vXIT0bFPOkn](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkn&open=AZ2Y3CQb8vXIT0bFPOkn) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `112`
- [AZ2Y3CQb8vXIT0bFPOko](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOko&open=AZ2Y3CQb8vXIT0bFPOko) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `126`
- [AZ2Y3CQb8vXIT0bFPOkq](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CQb8vXIT0bFPOkq&open=AZ2Y3CQb8vXIT0bFPOkq) `external_roslyn:CA1873` `LostFilmMonitoring.BLL.Tests/LoggerTests.cs` line `129`
- [AZ2Y3CKD8vXIT0bFPOkU](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CKD8vXIT0bFPOkU&open=AZ2Y3CKD8vXIT0bFPOkU) `external_roslyn:CA1873` `LostFilmMonitoring.BLL/Logger.cs` line `35`
- [AZ2Y3CKD8vXIT0bFPOkV](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CKD8vXIT0bFPOkV&open=AZ2Y3CKD8vXIT0bFPOkV) `external_roslyn:CA1873` `LostFilmMonitoring.BLL/Logger.cs` line `41`
- [AZ2Y3CKD8vXIT0bFPOkW](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CKD8vXIT0bFPOkW&open=AZ2Y3CKD8vXIT0bFPOkW) `external_roslyn:CA1873` `LostFilmMonitoring.BLL/Logger.cs` line `44`
- [AZ2Y3CKD8vXIT0bFPOkY](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CKD8vXIT0bFPOkY&open=AZ2Y3CKD8vXIT0bFPOkY) `external_roslyn:CA1873` `LostFilmMonitoring.BLL/Logger.cs` line `47`
- [AZ2Y3CKD8vXIT0bFPOkX](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZ2Y3CKD8vXIT0bFPOkX&open=AZ2Y3CKD8vXIT0bFPOkX) `external_roslyn:CA1873` `LostFilmMonitoring.BLL/Logger.cs` line `50`
- [AZHouJE9REFgCmEnWcGa](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AZHouJE9REFgCmEnWcGa&open=AZHouJE9REFgCmEnWcGa) `external_roslyn:CA1859` `LostFilmMonitoring.DAO.Azure.Tests/TestAsyncEnumerator.cs` line `6`
- [AYaA06hKWn4ib4avD7tU](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYaA06hKWn4ib4avD7tU&open=AYaA06hKWn4ib4avD7tU) `csharpsquid:S3878` `LostFilmMonitoring.BLL/Validators/EditSubscriptionRequestModelValidator.cs` line `46`
- [AYRuWTy2dJg9WPwtcPTL](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYRuWTy2dJg9WPwtcPTL&open=AYRuWTy2dJg9WPwtcPTL) `csharpsquid:S3925` `LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs` line `7`
- [AYRuWTy2dJg9WPwtcPTM](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYRuWTy2dJg9WPwtcPTM&open=AYRuWTy2dJg9WPwtcPTM) `csharpsquid:S1939` `LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs` line `7`
- [AYRuWT3FdJg9WPwtcPTO](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYRuWT3FdJg9WPwtcPTO&open=AYRuWT3FdJg9WPwtcPTO) `csharpsquid:S3925` `LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs` line `10`
- [AYRuWT3GdJg9WPwtcPTP](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYRuWT3GdJg9WPwtcPTP&open=AYRuWT3GdJg9WPwtcPTP) `csharpsquid:S1939` `LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs` line `10`
- [AYHs4CXLax0Oc53bvOA3](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYHs4CXLax0Oc53bvOA3&open=AYHs4CXLax0Oc53bvOA3) `csharpsquid:S1075` `LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs` line `8`
- [AYHnnrZRb_9NVAEX7EMB](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYHnnrZRb_9NVAEX7EMB&open=AYHnnrZRb_9NVAEX7EMB) `external_roslyn:CA1816` `LostFilmMonitoring.DAO.Azure.Tests/TestAsyncEnumerator.cs` line `17`
- [AYHnnrYWb_9NVAEX7EL-](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYHnnrYWb_9NVAEX7EL-&open=AYHnnrYWb_9NVAEX7EL-) `external_roslyn:CA1816` `LostFilmMonitoring.DAO.Azure.Tests/TestResponseOk.cs` line `13`

## Changed Files
- `LostFilmMonitoring.BLL.Tests/LoggerTests.cs`
- `LostFilmMonitoring.BLL/Commands/SaveSubscriptionCommand.cs`
- `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommand.cs`
- `LostFilmMonitoring.BLL/Commands/UpdateFeedsCommandDependencies.cs`
- `LostFilmMonitoring.BLL/Configuration.cs`
- `LostFilmMonitoring.BLL/Exceptions/ExternalServiceUnavailableException.cs`
- `LostFilmMonitoring.BLL/FeedItemResponse.cs`
- `LostFilmMonitoring.BLL/Logger.cs`
- `LostFilmMonitoring.BLL/Validators/EditSubscriptionRequestModelValidator.cs`
- `LostFilmMonitoring.Common/EnvironmentVariables.cs`
- `LostFilmMonitoring.Common/IConfiguration.cs`
- `LostFilmMonitoring.DAO.Azure.Tests/TestAsyncEnumerator.cs`
- `LostFilmMonitoring.DAO.Azure.Tests/TestResponseOk.cs`
- `LostFilmTV.Client.Tests/FeedItemResponseTests.cs`
- `LostFilmTV.Client.Tests/RssFeed/ReteOrgRssFeedTests.cs`
- `LostFilmTV.Client/Exceptions/RemoteServiceUnavailableException.cs`
- `LostFilmTV.Client/RssFeed/ReteOrgRssFeed.cs`
- `TMDB.Client/TmdbClient.cs`

## Resolution Summary
- `AZ8VQiPaaGlcg1M-FbfO`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfW`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfP`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfX`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfQ`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfY`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfR`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfZ`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfS`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-Fbfa`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfT`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-Fbfb`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfU`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-Fbfc`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-FbfV`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPaaGlcg1M-Fbfd`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfe`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbff`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfg`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfh`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfi`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfj`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfk`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiPtaGlcg1M-Fbfl`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ8VQiUuaGlcg1M-Fbfm`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOka`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOke`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOki`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkm`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkp`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZwdwDp8rlb-ZKk71zU1`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZW2D1JIc1xxlVLzcy2_`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZW2D1ONc1xxlVLzcy7J`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkZ`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkb`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkc`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkd`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkf`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkg`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkh`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkj`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkk`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkl`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkn`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOko`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CQb8vXIT0bFPOkq`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CKD8vXIT0bFPOkU`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CKD8vXIT0bFPOkV`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CKD8vXIT0bFPOkW`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CKD8vXIT0bFPOkY`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZ2Y3CKD8vXIT0bFPOkX`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AZHouJE9REFgCmEnWcGa`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYaA06hKWn4ib4avD7tU`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYRuWTy2dJg9WPwtcPTL`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYRuWTy2dJg9WPwtcPTM`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYRuWT3FdJg9WPwtcPTO`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYRuWT3GdJg9WPwtcPTP`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYHs4CXLax0Oc53bvOA3`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYHnnrZRb_9NVAEX7EMB`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.
- `AYHnnrYWb_9NVAEX7EL-`: attempted by GitHub Copilot CLI. Review the diff to confirm the issue is fully resolved.

## Skipped Or Not Fixed
- The automation cannot conclusively verify SonarQube closure until SonarQube re-analyzes this branch.

## Review Notes
- These changes were generated using GitHub Copilot CLI from selected SonarQube issue context.
- Human review is required before merge.
- Validation is delegated to the repository's pull request checks.
- Verify that no unrelated behavior, formatting, generated files, or security-sensitive values were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSS feed URL is now configurable across the app and deployment environments.
  * RSS feed loading now uses the configured URL instead of a fixed value.
  * Added richer comparison behavior for feed items, improving sorting and equality handling.

* **Bug Fixes**
  * Logging now respects enabled log levels before writing messages.
  * Exception handling and constructor validation were tightened for more consistent error reporting.

* **Tests**
  * Updated tests to cover the new RSS feed configuration and related logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->