### PR TITLE
Fix SonarQube issues for lAnubisl_LostFilmTorrentsFeed

### DIFF
--- a/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Commands/UpdateFeedsCommandTests.cs
@@ -602,8 +602,7 @@ public class UpdateFeedsCommandTests
                 null,
                 "http://n.tracktor.site/rssdownloader.php?id=51440",
                 null,
-                8, 8, 8,
-                14, 14, 14)
+                new QualityEpisodeInfoCollection(8,8,8, 14,14,14))
         ]);
 
         SetupTorrentFile("51439");

--- a/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
+++ b/LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs
@@ -93,7 +93,7 @@ public class EditSubscriptionRequestModelValidatorTests
     [Test]
     public async Task ValidateAsync_should_return_success()
     {
-        var testSeries = new Series(Guid.Parse("11111111-1111-1111-1111-111111111111"), string.Empty, DateTime.UtcNow, string.Empty, null, null, null, null, null, null, null, null, null);
+        var testSeries = new Series(Guid.Parse("11111111-1111-1111-1111-111111111111"), string.Empty, DateTime.UtcNow, string.Empty, null, null, null);
         this.seriesDao!.Setup(x => x.LoadAsync()).ReturnsAsync([testSeries]);
         this.userDao!.Setup(x => x.LoadAsync("userId")).ReturnsAsync(new User(string.Empty, string.Empty));
         var result = await GetService().ValidateAsync(new EditSubscriptionRequestModel() { UserId = "userId", Items = [new SubscriptionItem() { SeriesId = "11111111-1111-1111-1111-111111111111", Quality = "SD" }] });

--- a/LostFilmMonitoring.BLL/Extensions.cs
+++ b/LostFilmMonitoring.BLL/Extensions.cs
@@ -83,7 +83,7 @@ public static class Extensions
             return null;
         }
 
-        return new (
+        return new Series(
             Guid.Empty,
             feedItem.SeriesName,
             feedItem.PublishDateParsed,
@@ -91,12 +91,13 @@ public static class Extensions
             ParseLink(feedItem, Quality.SD),
             ParseLink(feedItem, Quality.H720),
             ParseLink(feedItem, Quality.H1080),
-            ParseSeasonNumber(feedItem, Quality.H1080),
-            ParseSeasonNumber(feedItem, Quality.H720),
-            ParseSeasonNumber(feedItem, Quality.SD),
-            ParseEpisodeNumber(feedItem, Quality.H1080),
-            ParseEpisodeNumber(feedItem, Quality.H720),
-            ParseEpisodeNumber(feedItem, Quality.SD));
+            new QualityEpisodeInfoCollection(
+                ParseSeasonNumber(feedItem, Quality.H1080),
+                ParseEpisodeNumber(feedItem, Quality.H1080),
+                ParseSeasonNumber(feedItem, Quality.H720),
+                ParseEpisodeNumber(feedItem, Quality.H720),
+                ParseSeasonNumber(feedItem, Quality.SD),
+                ParseEpisodeNumber(feedItem, Quality.SD)));
     }
 
     /// <summary>

--- a/LostFilmMonitoring.DAO.Azure/Mapper.cs
+++ b/LostFilmMonitoring.DAO.Azure/Mapper.cs
@@ -110,12 +110,13 @@ internal static class Mapper
             entity.LastEpisodeTorrentLinkSD,
             entity.LastEpisodeTorrentLinkMP4,
             entity.LastEpisodeTorrentLink1080,
-            entity.SeasonNumber1080,
-            entity.SeasonNumberMP4,
-            entity.SeasonNumberSD,
-            entity.EpisodeNumber1080,
-            entity.EpisodeNumberMP4,
-            entity.EpisodeNumberSD);
+            new QualityEpisodeInfoCollection(
+                entity.SeasonNumber1080,
+                entity.EpisodeNumber1080,
+                entity.SeasonNumberMP4,
+                entity.EpisodeNumberMP4,
+                entity.SeasonNumberSD,
+                entity.EpisodeNumberSD));
 
     /// <summary>
     /// Map <see cref="UserTableEntity"/> to <see cref="User"/>.

--- a/LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfo.cs
+++ b/LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfo.cs
@@ -1,0 +1,28 @@
+namespace LostFilmMonitoring.DAO.Interfaces.DomainModels;
+
+/// <summary>
+/// Quality-specific episode information.
+/// </summary>
+public class QualityEpisodeInfo
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QualityEpisodeInfo"/> class.
+    /// </summary>
+    /// <param name="seasonNumber">Season number for last episode of this quality.</param>
+    /// <param name="episodeNumber">Episode number for last episode of this quality.</param>
+    public QualityEpisodeInfo(int? seasonNumber, int? episodeNumber)
+    {
+        this.SeasonNumber = seasonNumber;
+        this.EpisodeNumber = episodeNumber;
+    }
+
+    /// <summary>
+    /// Gets season number for last episode of this quality.
+    /// </summary>
+    public int? SeasonNumber { get; }
+
+    /// <summary>
+    /// Gets episode number for last episode of this quality.
+    /// </summary>
+    public int? EpisodeNumber { get; }
+}

--- a/LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfoCollection.cs
+++ b/LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfoCollection.cs
@@ -1,0 +1,44 @@
+namespace LostFilmMonitoring.DAO.Interfaces.DomainModels;
+
+/// <summary>
+/// Collection of quality-specific episode information.
+/// </summary>
+public class QualityEpisodeInfoCollection
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QualityEpisodeInfoCollection"/> class.
+    /// </summary>
+    /// <param name="q1080SeasonNumber">Season number for last episode of quality 1080p.</param>
+    /// <param name="q1080EpisodeNumber">Episode number for last episode of quality 1080p.</param>
+    /// <param name="qMP4SeasonNumber">Season number for last episode of quality 720p.</param>
+    /// <param name="qMP4EpisodeNumber">Episode number for last episode of quality 720p.</param>
+    /// <param name="qSDSeasonNumber">Season number for last episode of quality SD.</param>
+    /// <param name="qSDEpisodeNumber">Episode number for last episode of quality SD.</param>
+    public QualityEpisodeInfoCollection(
+        int? q1080SeasonNumber,
+        int? q1080EpisodeNumber,
+        int? qMP4SeasonNumber,
+        int? qMP4EpisodeNumber,
+        int? qSDSeasonNumber,
+        int? qSDEpisodeNumber)
+    {
+        this.Q1080 = new QualityEpisodeInfo(q1080SeasonNumber, q1080EpisodeNumber);
+        this.QMP4 = new QualityEpisodeInfo(qMP4SeasonNumber, qMP4EpisodeNumber);
+        this.QSD = new QualityEpisodeInfo(qSDSeasonNumber, qSDEpisodeNumber);
+    }
+
+    /// <summary>
+    /// Gets quality-specific episode information for 1080p quality.
+    /// </summary>
+    public QualityEpisodeInfo Q1080 { get; }
+
+    /// <summary>
+    /// Gets quality-specific episode information for MP4 (720p) quality.
+    /// </summary>
+    public QualityEpisodeInfo QMP4 { get; }
+
+    /// <summary>
+    /// Gets quality-specific episode information for SD quality.
+    /// </summary>
+    public QualityEpisodeInfo QSD { get; }
+}

--- a/LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs
+++ b/LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs
@@ -31,11 +31,6 @@ public class Series
             linkSD,
             linkMP4,
             link1080,
-            null,
-            null,
-            null,
-            null,
-            null,
             null)
     {
     }
@@ -50,13 +45,51 @@ public class Series
     /// <param name="linkSD">Link to torrent file SD.</param>
     /// <param name="linkMP4">Link to torrent file MP4.</param>
     /// <param name="link1080">Link to torrent file 1080.</param>
+    /// <param name="qualityEpisodeInfos">Quality-specific episode information (1080p, MP4, SD).</param>
+    public Series(
+        Guid id,
+        string name,
+        DateTime lastEposide,
+        string lastEpisodeName,
+        string? linkSD,
+        string? linkMP4,
+        string? link1080,
+        QualityEpisodeInfoCollection? qualityEpisodeInfos = null)
+    {
+        this.Id = id;
+        this.Name = name;
+        this.LastEpisode = lastEposide;
+        this.LastEpisodeName = lastEpisodeName;
+        this.LastEpisodeTorrentLinkSD = linkSD;
+        this.LastEpisodeTorrentLinkMP4 = linkMP4;
+        this.LastEpisodeTorrentLink1080 = link1080;
+
+        qualityEpisodeInfos ??= new QualityEpisodeInfoCollection(null, null, null, null, null, null);
+        this.Q1080EpisodeNumber = qualityEpisodeInfos.Q1080?.EpisodeNumber;
+        this.QMP4EpisodeNumber = qualityEpisodeInfos.QMP4?.EpisodeNumber;
+        this.QSDEpisodeNumber = qualityEpisodeInfos.QSD?.EpisodeNumber;
+        this.Q1080SeasonNumber = qualityEpisodeInfos.Q1080?.SeasonNumber;
+        this.QMP4SeasonNumber = qualityEpisodeInfos.QMP4?.SeasonNumber;
+        this.QSDSeasonNumber = qualityEpisodeInfos.QSD?.SeasonNumber;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Series"/> class (for backward compatibility).
+    /// </summary>
+    /// <param name="id">Series id.</param>
+    /// <param name="name">Series name.</param>
+    /// <param name="lastEposide">Last episode date.</param>
+    /// <param name="lastEpisodeName">Last episode name.</param>
+    /// <param name="linkSD">Link to torrent file SD.</param>
+    /// <param name="linkMP4">Link to torrent file MP4.</param>
+    /// <param name="link1080">Link to torrent file 1080.</param>
     /// <param name="q1080SeasonNumber">Season number for last episode of quality 1080p.</param>
     /// <param name="qMP4SeasonNumber">Season number for last episode of quality 720p.</param>
     /// <param name="qSDSeasonNumber">Season number for last episode of quality SD.</param>
     /// <param name="q1080EpisodeNumber">Episode number for last episode of quality 1080p.</param>
     /// <param name="qMP4EpisodeNumber">Episode number for last episode of quality 720p.</param>
     /// <param name="qSDEpisodeNumber">Episode number for last episode of quality SD.</param>
-    public Series(
+    internal Series(
         Guid id,
         string name,
         DateTime lastEposide,
@@ -70,20 +103,22 @@ public class Series
         int? q1080EpisodeNumber,
         int? qMP4EpisodeNumber,
         int? qSDEpisodeNumber)
+        : this(
+            id,
+            name,
+            lastEposide,
+            lastEpisodeName,
+            linkSD,
+            linkMP4,
+            link1080,
+            new QualityEpisodeInfoCollection(
+                q1080SeasonNumber,
+                q1080EpisodeNumber,
+                qMP4SeasonNumber,
+                qMP4EpisodeNumber,
+                qSDSeasonNumber,
+                qSDEpisodeNumber))
     {
-        this.Id = id;
-        this.Name = name;
-        this.LastEpisode = lastEposide;
-        this.LastEpisodeName = lastEpisodeName;
-        this.LastEpisodeTorrentLinkSD = linkSD;
-        this.LastEpisodeTorrentLinkMP4 = linkMP4;
-        this.LastEpisodeTorrentLink1080 = link1080;
-        this.Q1080EpisodeNumber = q1080EpisodeNumber;
-        this.QMP4EpisodeNumber = qMP4EpisodeNumber;
-        this.QSDEpisodeNumber = qSDEpisodeNumber;
-        this.Q1080SeasonNumber = q1080SeasonNumber;
-        this.QMP4SeasonNumber = qMP4SeasonNumber;
-        this.QSDSeasonNumber = qSDSeasonNumber;
     }
 
     /// <summary>

--- a/LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs
+++ b/LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs
@@ -54,7 +54,7 @@ public class Series
         string? linkSD,
         string? linkMP4,
         string? link1080,
-        QualityEpisodeInfoCollection? qualityEpisodeInfos = null)
+        QualityEpisodeInfoCollection? qualityEpisodeInfos)
     {
         this.Id = id;
         this.Name = name;
@@ -71,54 +71,6 @@ public class Series
         this.Q1080SeasonNumber = qualityEpisodeInfos.Q1080?.SeasonNumber;
         this.QMP4SeasonNumber = qualityEpisodeInfos.QMP4?.SeasonNumber;
         this.QSDSeasonNumber = qualityEpisodeInfos.QSD?.SeasonNumber;
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="Series"/> class (for backward compatibility).
-    /// </summary>
-    /// <param name="id">Series id.</param>
-    /// <param name="name">Series name.</param>
-    /// <param name="lastEposide">Last episode date.</param>
-    /// <param name="lastEpisodeName">Last episode name.</param>
-    /// <param name="linkSD">Link to torrent file SD.</param>
-    /// <param name="linkMP4">Link to torrent file MP4.</param>
-    /// <param name="link1080">Link to torrent file 1080.</param>
-    /// <param name="q1080SeasonNumber">Season number for last episode of quality 1080p.</param>
-    /// <param name="qMP4SeasonNumber">Season number for last episode of quality 720p.</param>
-    /// <param name="qSDSeasonNumber">Season number for last episode of quality SD.</param>
-    /// <param name="q1080EpisodeNumber">Episode number for last episode of quality 1080p.</param>
-    /// <param name="qMP4EpisodeNumber">Episode number for last episode of quality 720p.</param>
-    /// <param name="qSDEpisodeNumber">Episode number for last episode of quality SD.</param>
-    internal Series(
-        Guid id,
-        string name,
-        DateTime lastEposide,
-        string lastEpisodeName,
-        string? linkSD,
-        string? linkMP4,
-        string? link1080,
-        int? q1080SeasonNumber,
-        int? qMP4SeasonNumber,
-        int? qSDSeasonNumber,
-        int? q1080EpisodeNumber,
-        int? qMP4EpisodeNumber,
-        int? qSDEpisodeNumber)
-        : this(
-            id,
-            name,
-            lastEposide,
-            lastEpisodeName,
-            linkSD,
-            linkMP4,
-            link1080,
-            new QualityEpisodeInfoCollection(
-                q1080SeasonNumber,
-                q1080EpisodeNumber,
-                qMP4SeasonNumber,
-                qMP4EpisodeNumber,
-                qSDSeasonNumber,
-                qSDEpisodeNumber))
-    {
     }
 
     /// <summary>


### PR DESCRIPTION
## Fix SonarQube issues for `lAnubisl_LostFilmTorrentsFeed`

| Field | Value |
| --- | --- |
| SonarQube project | `lAnubisl_LostFilmTorrentsFeed` |
| SonarQube branch | `master` |
| Base branch | `master` |
| Generated branch | `copilot/sonar-fixes/lAnubisl_LostFilmTorrentsFeed/20260701072218` |
| Issues selected | `1` |
| Issues attempted | `1` |

## Copilot Session Summary

```text
Changes    +150 -39
AI Credits 39.9 (5m 52s)
Tokens     ↑ 2.0m (1.9m cached, 96.2k written) • ↓ 18.0k (4.6k reasoning)
```

## Issue List
- [AYG10SOYqBn2UjaGtpUa](https://sonarcloud.io/project/issues?id=lAnubisl_LostFilmTorrentsFeed&issues=AYG10SOYqBn2UjaGtpUa&open=AYG10SOYqBn2UjaGtpUa) `csharpsquid:S107` `LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs` line `59`

## Changed Files
- `LostFilmMonitoring.BLL.Tests/Validation/EditSubscriptionRequestModelValidatorTests.cs`
- `LostFilmMonitoring.BLL/Extensions.cs`
- `LostFilmMonitoring.DAO.Azure/Mapper.cs`
- `LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfo.cs`
- `LostFilmMonitoring.DAO.Interfaces/DomainModels/QualityEpisodeInfoCollection.cs`
- `LostFilmMonitoring.DAO.Interfaces/DomainModels/Series.cs`

## Review Notes
- These changes were generated using GitHub Copilot CLI from selected SonarQube issue context.
- Human review is required before merge.
- Validation is delegated to the repository's pull request checks.
- Verify that no unrelated behavior, formatting, generated files, or security-sensitive values were changed.
